### PR TITLE
Update static 'framework name' in project to FastStream-2016 (fixes Test Data Generator users)

### DIFF
--- a/app/connectors/ExchangeObjects.scala
+++ b/app/connectors/ExchangeObjects.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.Json
 
 object ExchangeObjects {
 
-  val frameworkId = "FastTrack-2015"
+  val frameworkId = "FastStream-2016"
 
   case class UserEmail(to: List[String], templateId: String, parameters: Map[String, String])
 

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -100,14 +100,14 @@ trait ApplicationController extends BaseController {
       data.adjustments match {
         case Some(list) if list.nonEmpty =>
           appRepository.confirmAdjustment(applicationId, data).map { _ =>
-            auditService.logEvent("AjustmentsConfirmed")
+            auditService.logEvent("AdjustmentsConfirmed")
             Ok
           }.recover {
             case e: ApplicationNotFound => NotFound(s"cannot find application for user with id: ${e.id}")
           }
         case _ =>
           appRepository.rejectAdjustment(applicationId).map { _ =>
-            auditService.logEvent("AjustmentsRejected")
+            auditService.logEvent("AdjustmentsRejected")
             Ok
           }.recover {
             case e: ApplicationNotFound => NotFound(s"cannot find application for user with id: ${e.id}")

--- a/app/repositories/application/TestDataRepository.scala
+++ b/app/repositories/application/TestDataRepository.scala
@@ -16,13 +16,14 @@
 
 package repositories.application
 
+import connectors.ExchangeObjects
 import model.Commands._
 import model.Address
 import model.PersistedObjects
 import model.PersistedObjects.ContactDetails
-import org.joda.time.{ DateTime, LocalDate }
+import org.joda.time.{DateTime, LocalDate}
 import reactivemongo.api.DB
-import reactivemongo.bson.{ BSONArray, BSONDocument, BSONObjectID }
+import reactivemongo.bson.{BSONArray, BSONDocument, BSONObjectID}
 import repositories._
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
@@ -135,7 +136,7 @@ class TestDataMongoRepository(implicit mongo: () => DB)
     var document = BSONDocument(
       "applicationId" -> id.toString,
       "userId" -> id.toString,
-      "frameworkId" -> "FastTrack-2015",
+      "frameworkId" -> ExchangeObjects.frameworkId,
       "applicationStatus" -> applicationStatus
     )
     document = buildDocument(document)(personalDetails.map(d => "personal-details" -> d))

--- a/app/services/testdata/CreatedStatusGenerator.scala
+++ b/app/services/testdata/CreatedStatusGenerator.scala
@@ -16,8 +16,8 @@
 
 package services.testdata
 
-import connectors.AuthProviderClient
-import model.PersistedObjects.{ PersistedAnswer, PersistedQuestion }
+import connectors.{AuthProviderClient, ExchangeObjects}
+import model.PersistedObjects.{PersistedAnswer, PersistedQuestion}
 import repositories._
 import repositories.application.GeneralApplicationRepository
 import services.testdata.faker.DataFaker._
@@ -98,7 +98,7 @@ trait CreatedStatusGenerator extends ConstructiveGenerator {
   )
 
   private def createApplication(userId: String): Future[String] = {
-    appRepository.create(userId, "FastTrack-2015").map { application =>
+    appRepository.create(userId, ExchangeObjects.frameworkId).map { application =>
       application.applicationId
     }
   }

--- a/it/repositories/ApplicationRepositorySpec.scala
+++ b/it/repositories/ApplicationRepositorySpec.scala
@@ -34,7 +34,7 @@ class ApplicationRepositorySpec extends MongoRepositorySpec {
 
   import ImplicitBSONHandlers._
 
-  val frameworkId = "FastTrack-2015"
+  val frameworkId = "FastStream-2016"
 
   val collectionName = "application"
 
@@ -184,7 +184,7 @@ class ApplicationRepositorySpec extends MongoRepositorySpec {
 
   "return the adjustments report" should {
     "return a list of AdjustmentReports" in {
-      val frameworkId = "FastTrack-2015"
+      val frameworkId = "FastStream-2016"
 
       lazy val testData = new TestDataMongoRepository()
       testData.createApplications(1000).futureValue

--- a/it/repositories/DiagnosticReportRepositorySpec.scala
+++ b/it/repositories/DiagnosticReportRepositorySpec.scala
@@ -43,7 +43,7 @@ class DiagnosticReportRepositorySpec extends MongoRepositorySpec {
 
       val result = diagnosticReportRepo.findByUserId("user1").futureValue
 
-      val expectedApplicationUser = ApplicationUser("app1", "user1", "FastTrack-2015", "AWAITING_ALLOCATION",
+      val expectedApplicationUser = ApplicationUser("app1", "user1", "FastStream-2016", "AWAITING_ALLOCATION",
         ApplicationProgressStatuses(Some(List(
           ApplicationProgressStatus("registered", true),
           ApplicationProgressStatus("personal_details_completed", true),
@@ -72,7 +72,7 @@ class DiagnosticReportRepositorySpec extends MongoRepositorySpec {
 
       val result = diagnosticReportRepo.findByUserId("user1").futureValue
 
-      val expectedApplicationUser = ApplicationUser("app1", "user1", "FastTrack-2015", "SUBMITED",
+      val expectedApplicationUser = ApplicationUser("app1", "user1", "FastStream-2016", "SUBMITED",
         ApplicationProgressStatuses(Some(List(
           ApplicationProgressStatus("registered", true),
           ApplicationProgressStatus("personal_details_completed", true),
@@ -96,7 +96,7 @@ class DiagnosticReportRepositorySpec extends MongoRepositorySpec {
 
       val result = diagnosticReportRepo.findByUserId("user1").futureValue
 
-      val expectedApplicationUser = ApplicationUser("app1", "user1", "FastTrack-2015", "CREATED",
+      val expectedApplicationUser = ApplicationUser("app1", "user1", "FastStream-2016", "CREATED",
         ApplicationProgressStatuses(Some(List(
           ApplicationProgressStatus("registered", true)
         )), None))
@@ -110,7 +110,7 @@ class DiagnosticReportRepositorySpec extends MongoRepositorySpec {
   val UserWithAllDetails = BSONDocument(
     "applicationId" -> "app1",
     "userId" -> "user1",
-    "frameworkId" -> "FastTrack-2015",
+    "frameworkId" -> "FastStream-2016",
     "applicationStatus" -> "AWAITING_ALLOCATION",
     "progress-status" -> BSONDocument(
       "registered" -> BSONBoolean(true),
@@ -134,7 +134,7 @@ class DiagnosticReportRepositorySpec extends MongoRepositorySpec {
   val UserWithoutQuestionnaire = BSONDocument(
     "applicationId" -> "app1",
     "userId" -> "user1",
-    "frameworkId" -> "FastTrack-2015",
+    "frameworkId" -> "FastStream-2016",
     "applicationStatus" -> "SUBMITED",
     "progress-status" -> BSONDocument(
       "registered" -> BSONBoolean(true),
@@ -152,7 +152,7 @@ class DiagnosticReportRepositorySpec extends MongoRepositorySpec {
   val UserWithOnlyRegistedStatus = BSONDocument(
     "applicationId" -> "app1",
     "userId" -> "user1",
-    "frameworkId" -> "FastTrack-2015",
+    "frameworkId" -> "FastStream-2016",
     "applicationStatus" -> "CREATED"
   )
 }

--- a/it/repositories/application/GeneralApplicationMongoRepositorySpec.scala
+++ b/it/repositories/application/GeneralApplicationMongoRepositorySpec.scala
@@ -35,9 +35,9 @@ class GeneralApplicationMongoRepositorySpec extends MongoRepositorySpec with UUI
     "Get overall report for an application with all fields" in {
       val userId = generateUUID()
       val appId = generateUUID()
-      createApplicationWithAllFields(userId, appId, "FastTrack-2015")
+      createApplicationWithAllFields(userId, appId, "FastStream-2016")
 
-      val result = repository.overallReport("FastTrack-2015").futureValue
+      val result = repository.overallReport("FastStream-2016").futureValue
 
       result must not be empty
       result.head must be(Report(
@@ -52,9 +52,9 @@ class GeneralApplicationMongoRepositorySpec extends MongoRepositorySpec with UUI
     "Get overall report for the minimum application" in {
       val userId = generateUUID()
       val appId = generateUUID()
-      createMinimumApplication(userId, appId, "FastTrack-2015")
+      createMinimumApplication(userId, appId, "FastStream-2016")
 
-      val result = repository.overallReport("FastTrack-2015").futureValue
+      val result = repository.overallReport("FastStream-2016").futureValue
 
       result must not be empty
       result.head must be(Report(appId, Some("registered"),

--- a/test/controllers/ApplicationControllerSpec.scala
+++ b/test/controllers/ApplicationControllerSpec.scala
@@ -48,7 +48,7 @@ class ApplicationControllerSpec extends PlaySpec with MockitoSugar with Results 
         s"""
            |{
            |  "userId":"1234",
-           |  "frameworkId":"FASTTRACK-2015"
+           |  "frameworkId":"FASTSTREAM-2016"
            |}
         """.stripMargin
       ))

--- a/test/controllers/DiagnosticReportControllerSpec.scala
+++ b/test/controllers/DiagnosticReportControllerSpec.scala
@@ -36,7 +36,7 @@ class DiagnosticReportControllerSpec extends PlaySpec with Results with MockitoS
 
   "Get user by id" should {
     "return all information about the user" in new TestFixture {
-      val applicationUser = ApplicationUser("app1", "user1", "FastTrack-2015", "AWAITING_ALLOCATION",
+      val applicationUser = ApplicationUser("app1", "user1", "FastStream-2016", "AWAITING_ALLOCATION",
         ApplicationProgressStatuses(None, None))
       when(mockSecretReportRepository.findByUserId("user1")).thenReturn(Future.successful(applicationUser))
       val result = TestableSecretReportingController.getUserById(applicationUser.userId)(createOnlineTestRequest(

--- a/test/controllers/ReportControllerSpec.scala
+++ b/test/controllers/ReportControllerSpec.scala
@@ -374,7 +374,7 @@ class ReportControllerSpec extends PlaySpec with Results with MockitoSugar {
   }
 
   trait TestFixture extends TestFixtureBase {
-    val frameworkId = "FastTrack-2015"
+    val frameworkId = "FastStream-2016"
 
     def createAdjustmentsReport(frameworkId: String) = {
       FakeRequest(Helpers.GET, controllers.routes.ReportingController.createAdjustmentReports(frameworkId).url, FakeHeaders(), "")


### PR DESCRIPTION
- Fix a typo of 'ajustments' for the new project, no more misspelt audit logs - hurray!

- Update the default framework name in faststream to match faststream-frontend (this was also stopping the test data generator users being properly loaded when testing

Tangentially related to work on FSET-647 (we can now use the generator which will save us lots of time)