### PR TITLE
Bug fix in Application Validator when gis = false

### DIFF
--- a/app/model/ApplicationValidator.scala
+++ b/app/model/ApplicationValidator.scala
@@ -41,7 +41,7 @@ case class ApplicationValidator(gd: PersonalDetails, ad: AssistanceDetails, sl: 
     val ifNeedsVenueAdjustments = ifNeeds(Some(ad.needsSupportAtVenue)) _
 
     def hasGis(ad: AssistanceDetails): Boolean = ad.guaranteedInterview match {
-      case Some(x) => x
+      case Some(_) => true
       case _ => false
     }
 


### PR DESCRIPTION
the method hasGis is intented to check if you have a value in hasGis, not to check if that value is true.