### PR TITLE
Schedule completion URLs for Cubiks

### DIFF
--- a/app/config/microserviceAppConfig.scala
+++ b/app/config/microserviceAppConfig.scala
@@ -51,7 +51,7 @@ case class WaitingScheduledJobConfig(
 ) extends ScheduledJobConfigurable
 
 case class CubiksGatewayConfig(url: String,
-  phase1TestsConfig: Phase1TestsConfig,
+  phase1Tests: Phase1TestsConfig,
   competenceAssessment: CubiksGatewayStandardAssessment,
   situationalAssessment: CubiksGatewayStandardAssessment,
   reportConfig: ReportConfig,

--- a/app/config/microserviceAppConfig.scala
+++ b/app/config/microserviceAppConfig.scala
@@ -51,7 +51,7 @@ case class WaitingScheduledJobConfig(
 ) extends ScheduledJobConfigurable
 
 case class CubiksGatewayConfig(url: String,
-  onlineTestConfig: CubiksOnlineTestConfig,
+  phase1TestsConfig: Phase1TestsConfig,
   competenceAssessment: CubiksGatewayStandardAssessment,
   situationalAssessment: CubiksGatewayStandardAssessment,
   reportConfig: ReportConfig,
@@ -59,8 +59,7 @@ case class CubiksGatewayConfig(url: String,
   emailDomain: String
 )
 
-case class CubiksOnlineTestConfig(phaseName: String,
-                                  expiryTimeInDays: Int,
+case class Phase1TestsConfig(expiryTimeInDays: Int,
                                   scheduleIds: Map[String, Int],
                                   standard: List[String],
                                   gis: List[String])

--- a/app/config/microserviceAppConfig.scala
+++ b/app/config/microserviceAppConfig.scala
@@ -50,11 +50,14 @@ case class WaitingScheduledJobConfig(
   waitSecs: Option[Int]
 ) extends ScheduledJobConfigurable
 
-case class CubiksGatewayConfig(url: String, onlineTestConfig: CubiksOnlineTestConfig,
-  verbalAndNumericalAssessment: CubiksGatewayVerbalAndNumericalAssessment,
+case class CubiksGatewayConfig(url: String,
+  onlineTestConfig: CubiksOnlineTestConfig,
   competenceAssessment: CubiksGatewayStandardAssessment,
   situationalAssessment: CubiksGatewayStandardAssessment,
-  reportConfig: ReportConfig, candidateAppUrl: String, emailDomain: String)
+  reportConfig: ReportConfig,
+  candidateAppUrl: String,
+  emailDomain: String
+)
 
 case class CubiksOnlineTestConfig(phaseName: String,
                                   expiryTimeInDays: Int,
@@ -68,17 +71,6 @@ trait CubiksGatewayAssessment {
 }
 
 case class CubiksGatewayStandardAssessment(assessmentId: Int, normId: Int) extends CubiksGatewayAssessment
-
-case class CubiksGatewayVerbalAndNumericalAssessment(
-  assessmentId: Int,
-  normId: Int,
-  verbalSectionId: Int,
-  verbalTimeInMinutesMinimum: Int,
-  verbalTimeInMinutesMaximum: Int,
-  numericalSectionId: Int,
-  numericalTimeInMinutesMinimum: Int,
-  numericalTimeInMinutesMaximum: Int
-) extends CubiksGatewayAssessment
 
 case class ReportConfig(xmlReportId: Int, pdfReportId: Int, localeCode: String, suppressValidation: Boolean = false)
 

--- a/app/controllers/OnlineTestController.scala
+++ b/app/controllers/OnlineTestController.scala
@@ -65,7 +65,7 @@ trait OnlineTestController extends BaseController {
   def getOnlineTest(userId: String) = Action.async { implicit request =>
     onlineTestingService.getPhase1TestProfile(userId).map {
       case Some(phase1TestProfileWithNames) => Ok(Json.toJson(phase1TestProfileWithNames))
-      case None => Logger.error(s"No phase 1 test found for userID [$userId]")
+      case None => Logger.info(s"No phase 1 test found for userID [$userId]")
         NotFound
     }
   }

--- a/app/services/onlinetesting/OnlineTestService.scala
+++ b/app/services/onlinetesting/OnlineTestService.scala
@@ -103,9 +103,9 @@ trait OnlineTestService {
     }
   }
 
-  private def sjq = gatewayConfig.onlineTestConfig.scheduleIds("sjq")
+  private def sjq = gatewayConfig.phase1TestsConfig.scheduleIds("sjq")
 
-  private def bq = gatewayConfig.onlineTestConfig.scheduleIds("bq")
+  private def bq = gatewayConfig.phase1TestsConfig.scheduleIds("bq")
 
   def registerAndInviteForTestGroup(application: OnlineTestApplication): Future[Unit] = {
     registerAndInviteForTestGroup(application, getScheduleNamesForApplication(application))
@@ -263,7 +263,7 @@ trait OnlineTestService {
 
   private def calcOnlineTestDates: (DateTime, DateTime) = {
     val invitationDate = dateTimeFactory.nowLocalTimeZone
-    val expirationDate = invitationDate.plusDays(gatewayConfig.onlineTestConfig.expiryTimeInDays)
+    val expirationDate = invitationDate.plusDays(gatewayConfig.phase1TestsConfig.expiryTimeInDays)
     (invitationDate, expirationDate)
   }
 
@@ -278,14 +278,14 @@ trait OnlineTestService {
 
   private def getScheduleNamesForApplication(application: OnlineTestApplication) = {
     if (application.guaranteedInterview) {
-      gatewayConfig.onlineTestConfig.gis
+      gatewayConfig.phase1TestsConfig.gis
     } else {
-      gatewayConfig.onlineTestConfig.standard
+      gatewayConfig.phase1TestsConfig.standard
     }
   }
 
   private def scheduleIdByName(name: String): Int = {
-    gatewayConfig.onlineTestConfig.scheduleIds.getOrElse(name, throw new IllegalArgumentException(s"Incorrect test name: $name"))
+    gatewayConfig.phase1TestsConfig.scheduleIds.getOrElse(name, throw new IllegalArgumentException(s"Incorrect test name: $name"))
   }
 
 

--- a/app/services/onlinetesting/OnlineTestService.scala
+++ b/app/services/onlinetesting/OnlineTestService.scala
@@ -74,8 +74,7 @@ trait OnlineTestService {
 
   def norms = Seq(
     gatewayConfig.competenceAssessment,
-    gatewayConfig.situationalAssessment,
-    gatewayConfig.verbalAndNumericalAssessment
+    gatewayConfig.situationalAssessment
   ).map(a => ReportNorm(a.assessmentId, a.normId)).toList
 
   def nextApplicationReadyForOnlineTesting() = {
@@ -289,28 +288,6 @@ trait OnlineTestService {
     gatewayConfig.onlineTestConfig.scheduleIds.getOrElse(name, throw new IllegalArgumentException(s"Incorrect test name: $name"))
   }
 
-  private[services] def getTimeAdjustments(application: OnlineTestApplication): Option[TimeAdjustments] = {
-    if (application.timeAdjustments.isEmpty) {
-      None
-    } else {
-      val config = gatewayConfig.verbalAndNumericalAssessment
-      Some(TimeAdjustments(
-        config.assessmentId,
-        config.verbalSectionId,
-        config.numericalSectionId,
-        getAdjustedTime(
-          config.verbalTimeInMinutesMinimum,
-          config.verbalTimeInMinutesMaximum,
-          application.timeAdjustments.get.verbalTimeAdjustmentPercentage
-        ),
-        getAdjustedTime(
-          config.numericalTimeInMinutesMinimum,
-          config.numericalTimeInMinutesMaximum,
-          application.timeAdjustments.get.numericalTimeAdjustmentPercentage
-        )
-      ))
-    }
-  }
 
   private[services] def getAdjustedTime(minimum: Int, maximum: Int, percentageToIncrease: Int) = {
     val adjustedValue = math.ceil(minimum.toDouble * (1 + percentageToIncrease / 100.0))
@@ -323,17 +300,16 @@ trait OnlineTestService {
       InviteApplicant(scheduleId,
         userId,
         s"$scheduleCompletionUrl/complete/$token",
-        resultsURL = None, timeAdjustments = None
+        resultsURL = None
       )
     } else {
-      val timeAdjustments = getTimeAdjustments(application)
       val completionUrl = if (scheduleIdByName("sjq") == scheduleId) {
         s"$scheduleCompletionUrl/continue/$token"
       } else {
         s"$scheduleCompletionUrl/complete/$token"
       }
 
-      InviteApplicant(scheduleId, userId, completionUrl, resultsURL = None, timeAdjustments)
+      InviteApplicant(scheduleId, userId, completionUrl, resultsURL = None)
     }
   }
 

--- a/app/services/onlinetesting/OnlineTestService.scala
+++ b/app/services/onlinetesting/OnlineTestService.scala
@@ -318,12 +318,22 @@ trait OnlineTestService {
   }
 
   private[services] def buildInviteApplication(application: OnlineTestApplication, token: String, userId: Int, scheduleId: Int) = {
-    val scheduleCompletionUrl = s"${gatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/complete/$token"
+    val scheduleCompletionUrl = s"${gatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests"
     if (application.guaranteedInterview) {
-      InviteApplicant(scheduleId, userId, scheduleCompletionUrl, resultsURL = None, timeAdjustments = None)
+      InviteApplicant(scheduleId,
+        userId,
+        s"$scheduleCompletionUrl/complete/$token",
+        resultsURL = None, timeAdjustments = None
+      )
     } else {
       val timeAdjustments = getTimeAdjustments(application)
-      InviteApplicant(scheduleId, userId, scheduleCompletionUrl, resultsURL = None, timeAdjustments)
+      val completionUrl = if (scheduleIdByName("sjq") == scheduleId) {
+        s"$scheduleCompletionUrl/continue/$token"
+      } else {
+        s"$scheduleCompletionUrl/complete/$token"
+      }
+
+      InviteApplicant(scheduleId, userId, completionUrl, resultsURL = None, timeAdjustments)
     }
   }
 

--- a/app/services/onlinetesting/OnlineTestService.scala
+++ b/app/services/onlinetesting/OnlineTestService.scala
@@ -295,21 +295,21 @@ trait OnlineTestService {
   }
 
   private[services] def buildInviteApplication(application: OnlineTestApplication, token: String, userId: Int, scheduleId: Int) = {
-    val scheduleCompletionUrl = s"${gatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/phase1"
+    val scheduleCompletionBaseUrl = s"${gatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/phase1"
     if (application.guaranteedInterview) {
       InviteApplicant(scheduleId,
         userId,
-        s"$scheduleCompletionUrl/complete/$token",
+        s"$scheduleCompletionBaseUrl/complete/$token",
         resultsURL = None
       )
     } else {
-      val completionUrl = if (scheduleIdByName("sjq") == scheduleId) {
-        s"$scheduleCompletionUrl/continue/$token"
+      val scheduleCompletionUrl = if (scheduleIdByName("sjq") == scheduleId) {
+        s"$scheduleCompletionBaseUrl/continue/$token"
       } else {
-        s"$scheduleCompletionUrl/complete/$token"
+        s"$scheduleCompletionBaseUrl/complete/$token"
       }
 
-      InviteApplicant(scheduleId, userId, completionUrl, resultsURL = None)
+      InviteApplicant(scheduleId, userId, scheduleCompletionUrl, resultsURL = None)
     }
   }
 

--- a/app/services/onlinetesting/OnlineTestService.scala
+++ b/app/services/onlinetesting/OnlineTestService.scala
@@ -295,7 +295,7 @@ trait OnlineTestService {
   }
 
   private[services] def buildInviteApplication(application: OnlineTestApplication, token: String, userId: Int, scheduleId: Int) = {
-    val scheduleCompletionUrl = s"${gatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests"
+    val scheduleCompletionUrl = s"${gatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/phase1"
     if (application.guaranteedInterview) {
       InviteApplicant(scheduleId,
         userId,

--- a/app/services/onlinetesting/OnlineTestService.scala
+++ b/app/services/onlinetesting/OnlineTestService.scala
@@ -103,9 +103,9 @@ trait OnlineTestService {
     }
   }
 
-  private def sjq = gatewayConfig.phase1TestsConfig.scheduleIds("sjq")
+  private def sjq = gatewayConfig.phase1Tests.scheduleIds("sjq")
 
-  private def bq = gatewayConfig.phase1TestsConfig.scheduleIds("bq")
+  private def bq = gatewayConfig.phase1Tests.scheduleIds("bq")
 
   def registerAndInviteForTestGroup(application: OnlineTestApplication): Future[Unit] = {
     registerAndInviteForTestGroup(application, getScheduleNamesForApplication(application))
@@ -263,7 +263,7 @@ trait OnlineTestService {
 
   private def calcOnlineTestDates: (DateTime, DateTime) = {
     val invitationDate = dateTimeFactory.nowLocalTimeZone
-    val expirationDate = invitationDate.plusDays(gatewayConfig.phase1TestsConfig.expiryTimeInDays)
+    val expirationDate = invitationDate.plusDays(gatewayConfig.phase1Tests.expiryTimeInDays)
     (invitationDate, expirationDate)
   }
 
@@ -278,14 +278,14 @@ trait OnlineTestService {
 
   private def getScheduleNamesForApplication(application: OnlineTestApplication) = {
     if (application.guaranteedInterview) {
-      gatewayConfig.phase1TestsConfig.gis
+      gatewayConfig.phase1Tests.gis
     } else {
-      gatewayConfig.phase1TestsConfig.standard
+      gatewayConfig.phase1Tests.standard
     }
   }
 
   private def scheduleIdByName(name: String): Int = {
-    gatewayConfig.phase1TestsConfig.scheduleIds.getOrElse(name, throw new IllegalArgumentException(s"Incorrect test name: $name"))
+    gatewayConfig.phase1Tests.scheduleIds.getOrElse(name, throw new IllegalArgumentException(s"Incorrect test name: $name"))
   }
 
 

--- a/app/services/testdata/Phase1TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/Phase1TestsInvitedStatusGenerator.scala
@@ -48,7 +48,7 @@ trait Phase1TestsInvitedStatusGenerator extends ConstructiveGenerator {
       invitationDate = generatorConfig.phase1StartTime.getOrElse(DateTime.now()).withDurationAdded(86400000, -1),
       // TODO: Add started datetime
       participantScheduleId = 149245,
-      scheduleId = gatewayConfig.onlineTestConfig.scheduleIds("sjq"),
+      scheduleId = gatewayConfig.phase1TestsConfig.scheduleIds("sjq"),
       usedForResults = true
     )
 
@@ -59,7 +59,7 @@ trait Phase1TestsInvitedStatusGenerator extends ConstructiveGenerator {
       invitationDate = generatorConfig.phase1StartTime.getOrElse(DateTime.now()).withDurationAdded(86400000, -1),
       // TODO: Add started datetime
       participantScheduleId = 149245,
-      scheduleId = gatewayConfig.onlineTestConfig.scheduleIds("bq"),
+      scheduleId = gatewayConfig.phase1TestsConfig.scheduleIds("bq"),
       usedForResults = true
     )
 

--- a/app/services/testdata/Phase1TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/Phase1TestsInvitedStatusGenerator.scala
@@ -48,7 +48,7 @@ trait Phase1TestsInvitedStatusGenerator extends ConstructiveGenerator {
       invitationDate = generatorConfig.phase1StartTime.getOrElse(DateTime.now()).withDurationAdded(86400000, -1),
       // TODO: Add started datetime
       participantScheduleId = 149245,
-      scheduleId = gatewayConfig.phase1TestsConfig.scheduleIds("sjq"),
+      scheduleId = gatewayConfig.phase1Tests.scheduleIds("sjq"),
       usedForResults = true
     )
 
@@ -59,7 +59,7 @@ trait Phase1TestsInvitedStatusGenerator extends ConstructiveGenerator {
       invitationDate = generatorConfig.phase1StartTime.getOrElse(DateTime.now()).withDurationAdded(86400000, -1),
       // TODO: Add started datetime
       participantScheduleId = 149245,
-      scheduleId = gatewayConfig.phase1TestsConfig.scheduleIds("bq"),
+      scheduleId = gatewayConfig.phase1Tests.scheduleIds("bq"),
       usedForResults = true
     )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,7 +91,7 @@ microservice {
     }
     cubiks-gateway {
       url = "http://localhost:9288"
-      onlineTestConfig = {
+      onlineTestConfig {
         phaseName = "phase1"
         expiryTimeInDays = 7
         scheduleIds = {
@@ -131,7 +131,7 @@ microservice {
 scheduling {
   online-testing {
     send-invitation-job {
-      enabled = false
+      enabled = true
       lockId = "send-invitation-job-lock-coordinator"
       initialDelaySecs = 30
       intervalSecs = 30

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -101,17 +101,6 @@ microservice {
         standard = [ sjq, bq ]
         gis = [ sjq ]
       }
-
-      verbalAndNumericalAssessment {
-        assessmentId = 132
-        normId = 907000310
-        verbalSectionId = 1
-        verbalTimeInMinutesMinimum = 6
-        verbalTimeInMinutesMaximum = 12
-        numericalSectionId = 2
-        numericalTimeInMinutesMinimum = 6
-        numericalTimeInMinutesMaximum = 12
-      }
       competenceAssessment {
         assessmentId = 127
         normId = 907000263

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -131,7 +131,7 @@ microservice {
 scheduling {
   online-testing {
     send-invitation-job {
-      enabled = true
+      enabled = false
       lockId = "send-invitation-job-lock-coordinator"
       initialDelaySecs = 30
       intervalSecs = 30

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,12 +91,11 @@ microservice {
     }
     cubiks-gateway {
       url = "http://localhost:9288"
-      onlineTestConfig {
-        phaseName = "phase1"
+      phase1TestsConfig {
         expiryTimeInDays = 7
-        scheduleIds = {
-          sjq : 16196
-          bq : 16194
+        scheduleIds {
+          sjq = 16196
+          bq = 16194
         }
         standard = [ sjq, bq ]
         gis = [ sjq ]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,7 +91,7 @@ microservice {
     }
     cubiks-gateway {
       url = "http://localhost:9288"
-      phase1TestsConfig {
+      phase1Tests {
         expiryTimeInDays = 7
         scheduleIds {
           sjq = 16196

--- a/test/services/onlinetesting/OnlineTestServiceSpec.scala
+++ b/test/services/onlinetesting/OnlineTestServiceSpec.scala
@@ -60,8 +60,8 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     emailDomain = "test.com"
   )
 
-  val sjqScheduleId =testGatewayConfig.phase1TestsConfig.scheduleIds("sjq")
-  val bqScheduleId =testGatewayConfig.phase1TestsConfig.scheduleIds("bq")
+  val sjqScheduleId =testGatewayConfig.phase1Tests.scheduleIds("sjq")
+  val bqScheduleId =testGatewayConfig.phase1Tests.scheduleIds("bq")
 
   val preferredName = "Preferred\tName"
   val preferredNameSanitized = "Preferred Name"
@@ -94,7 +94,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
   val invitationDate = DateTime.parse("2016-05-11")
   val expirationDate = invitationDate.plusDays(7)
-  val phase1Test = Phase1Test(scheduleId = testGatewayConfig.phase1TestsConfig.scheduleIds("sjq"),
+  val phase1Test = Phase1Test(scheduleId = testGatewayConfig.phase1Tests.scheduleIds("sjq"),
     usedForResults = true,
     cubiksUserId = cubiksUserId,
     token = token,
@@ -341,7 +341,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
     "return an InviteApplication for a non GIS candidate" in new OnlineTest {
       val sjqInvite = onlineTestService.buildInviteApplication(onlineTestApplication,
-        "token", cubiksUserId, testGatewayConfig.phase1TestsConfig.scheduleIds("sjq"))
+        "token", cubiksUserId, testGatewayConfig.phase1Tests.scheduleIds("sjq"))
 
       sjqInvite mustBe inviteApplicant.copy(
         scheduleID = sjqScheduleId,

--- a/test/services/onlinetesting/OnlineTestServiceSpec.scala
+++ b/test/services/onlinetesting/OnlineTestServiceSpec.scala
@@ -44,18 +44,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
   with PrivateMethodTester {
   implicit val ec: ExecutionContext = ExecutionContext.global
 
-  val VerbalAndNumericalAssessmentId = 1
-  val VerbalSectionId = 1
-  val NumericalSectionId = 2
-  val verbalTimeInMinutesMinimum = 6
-  val verbalTimeInMinutesMaximum = 12
-  val numericalTimeInMinutesMinimum = 6
-  val numericalTimeInMinutesMaximum = 12
-
-  val emailDomainMock = "mydomain.com"
-  val onlineTestCompletedUrlMock = "http://localhost:9284/fset-fast-stream/online-tests/complete/"
-  val gisScheduledIdMock = List(11111)
-  val standardScheduleIdMock = List(16196, 16194)
+  val scheduleCompletionBaseUrl = "http://localhost:9284/fset-fast-stream/online-tests/"
 
   val testGatewayConfig = CubiksGatewayConfig(
     "",
@@ -65,73 +54,56 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
       List("sjq", "bq"),
       List("sjq")
     ),
-    CubiksGatewayVerbalAndNumericalAssessment(
-      VerbalAndNumericalAssessmentId,
-      normId = 22,
-      VerbalSectionId, verbalTimeInMinutesMinimum, verbalTimeInMinutesMaximum, NumericalSectionId,
-      numericalTimeInMinutesMinimum, numericalTimeInMinutesMaximum
-    ),
-    CubiksGatewayStandardAssessment(31, 32),
-    CubiksGatewayStandardAssessment(41, 42),
+    competenceAssessment = CubiksGatewayStandardAssessment(31, 32),
+    situationalAssessment = CubiksGatewayStandardAssessment(41, 42),
     ReportConfig(1, 2, "en-GB"),
-    "http://localhost:9284",
-    emailDomainMock
+    candidateAppUrl = "http://localhost:9284",
+    emailDomain = "test.com"
   )
 
-  val ErrorMessage = "Error in connector"
+  val sjqScheduleId =testGatewayConfig.onlineTestConfig.scheduleIds("sjq")
+  val bqScheduleId =testGatewayConfig.onlineTestConfig.scheduleIds("bq")
 
-  val ApplicationId = "ApplicationId1"
-  val UserId = "1"
-  val GuaranteedInterviewFalse = false
-  val GuaranteedInterviewTrue = true
-  val NeedsAdjustment = false
-  val VerbalTimeAdjustmentPercentage = 6
-  val NumericalTimeAdjustmentPercentage = 6
-  val PreferredName = "Preferred\tName"
-  val PreferredNameSanitized = "Preferred Name"
-  val applicationForOnlineTestingWithNoTimeAdjustments = OnlineTestApplication(ApplicationId, ApplicationStatus.SUBMITTED, UserId,
-    GuaranteedInterviewFalse, NeedsAdjustment, PreferredName, None)
-  val timeAdjustments = TimeAdjustmentsOnlineTestApplication(VerbalTimeAdjustmentPercentage, NumericalTimeAdjustmentPercentage)
-  val applicationForOnlineTestingWithTimeAdjustments = OnlineTestApplication(ApplicationId, ApplicationStatus.SUBMITTED, UserId,
-    GuaranteedInterviewFalse, NeedsAdjustment, PreferredName, Some(timeAdjustments))
-  val applicationForOnlineTestingGisWithNoTimeAdjustments = OnlineTestApplication(ApplicationId, ApplicationStatus.SUBMITTED, UserId,
-    GuaranteedInterviewTrue, NeedsAdjustment, PreferredName, None)
-  val applicationForOnlineTestingGisWithTimeAdjustments = OnlineTestApplication(ApplicationId, ApplicationStatus.SUBMITTED, UserId,
-    GuaranteedInterviewTrue, NeedsAdjustment, PreferredName, Some(timeAdjustments))
+  val preferredName = "Preferred\tName"
+  val preferredNameSanitized = "Preferred Name"
 
-  val FirstName = PreferredName
-  val LastName = ""
-  val Token = "2222"
-  val EmailCubiks = Token + "@" + emailDomainMock
-  val registerApplicant = RegisterApplicant(PreferredNameSanitized, LastName, EmailCubiks)
+  val onlineTestApplication = OnlineTestApplication(applicationId = "appId",
+    applicationStatus = ApplicationStatus.SUBMITTED,
+    userId = "userId",
+    guaranteedInterview = false,
+    needsAdjustments = false,
+    preferredName,
+    timeAdjustments = None
+  )
 
-  val CubiksUserId = 2222
-  val registration = Registration(CubiksUserId)
+  val cubiksUserId = 98765
+  val lastName = ""
+  val token = "token"
+  val emailCubiks = token + "@" + testGatewayConfig.emailDomain
+  val registerApplicant = RegisterApplicant(preferredNameSanitized, lastName, emailCubiks)
+  val registration = Registration(cubiksUserId)
 
-  val ScheduleId = standardScheduleIdMock.head
+  val inviteApplicant = InviteApplicant(sjqScheduleId,
+    cubiksUserId, s"$scheduleCompletionBaseUrl/complete/$token",
+    resultsURL = None, timeAdjustments = None
+  )
 
-  val inviteApplicant = InviteApplicant(ScheduleId, CubiksUserId, onlineTestCompletedUrlMock, None, None)
-  val inviteApplicantGisWithNoTimeAdjustments = inviteApplicant
-  val inviteApplicantNoGisWithNoTimeAdjustments = inviteApplicant
-  val timeAdjustmentsForInviteApplicant = TimeAdjustments(VerbalAndNumericalAssessmentId, VerbalSectionId, NumericalSectionId,
-    7, 7)
-  val inviteApplicantNoGisWithTimeAdjustments = inviteApplicant.copy(timeAdjustments = Some(timeAdjustmentsForInviteApplicant))
-  val AccessCode = "fdkfdfj"
-  val LogonUrl = "http://localhost/logonUrl"
-  val AuthenticateUrl = "http://localhost/authenticate"
-  val invitation = Invitation(CubiksUserId, EmailCubiks, AccessCode, LogonUrl, AuthenticateUrl, ScheduleId)
+  val accessCode = "fdkfdfj"
+  val logonUrl = "http://localhost/logonUrl"
+  val authenticateUrl = "http://localhost/authenticate"
+  val invitation = Invitation(cubiksUserId, emailCubiks, accessCode, logonUrl, authenticateUrl, sjqScheduleId)
 
-  val InvitationDate = DateTime.parse("2016-05-11")
-  val ExpirationDate = InvitationDate.plusDays(7)
-  val phase1Test = Phase1Test(scheduleId = standardScheduleIdMock.head,
+  val invitationDate = DateTime.parse("2016-05-11")
+  val expirationDate = invitationDate.plusDays(7)
+  val phase1Test = Phase1Test(scheduleId = testGatewayConfig.onlineTestConfig.scheduleIds("sjq"),
     usedForResults = true,
-    cubiksUserId = CubiksUserId,
-    token = Token,
-    testUrl = AuthenticateUrl,
-    invitationDate = InvitationDate,
+    cubiksUserId = cubiksUserId,
+    token = token,
+    testUrl = authenticateUrl,
+    invitationDate = invitationDate,
     participantScheduleId = 234
   )
-  val phase1TestProfile = Phase1TestProfile(ExpirationDate,
+  val phase1TestProfile = Phase1TestProfile(expirationDate,
     List(phase1Test)
   )
 
@@ -140,15 +112,14 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     email = Some("test@test.com"), dateOfBirth = None, address = None, postCode = None, country = None
   )
 
-  val Postcode = "WC2B 4"
-  val EmailContactDetails = "emailfjjfjdf@mailinator.com"
-  val contactDetails = ContactDetails(Address("Aldwych road"), Postcode, EmailContactDetails, Some("111111"))
+  val postcode = "WC2B 4"
+  val emailContactDetails = "emailfjjfjdf@mailinator.com"
+  val contactDetails = ContactDetails(Address("Aldwych road"), postcode, emailContactDetails, Some("111111"))
 
-  val auditDetails = Map("userId" -> UserId)
-  val auditDetailsWithEmail = auditDetails + ("email" -> EmailContactDetails)
+  val auditDetails = Map("userId" -> "userId")
+  val auditDetailsWithEmail = auditDetails + ("email" -> emailContactDetails)
 
-  val MinimumAssessmentTime = 6
-  val MaximumAssessmentTime = 12
+  val connectorErrorMessage = "Error in connector"
 
   "get online test" should {
     "return None if the user does not exist" in new OnlineTest {
@@ -181,12 +152,15 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
   "register and invite application" should {
     "issue one email for invites to SJQ for GIS candidates" in new SuccessfulTestInviteFixture {
       when(otRepositoryMock.getPhase1TestProfile(any[String])).thenReturn(Future.successful(Some(phase1TestProfile)))
-      val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingGisWithNoTimeAdjustments)
+      val result = onlineTestService
+        .registerAndInviteForTestGroup(onlineTestApplication.copy(guaranteedInterview = true))
+
       result.futureValue mustBe (())
 
-      verify(emailClientMock, times(1)).sendOnlineTestInvitation(eqTo(EmailContactDetails), eqTo(PreferredName), eqTo(ExpirationDate))(
-        any[HeaderCarrier]
-      )
+      verify(emailClientMock, times(1)).sendOnlineTestInvitation(
+        eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate)
+      )(any[HeaderCarrier])
+
       verify(auditServiceMock, times(1)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
       verify(auditServiceMock, times(1)).logEventNoRequest("UserInvitedToOnlineTest", auditDetails)
       verify(auditServiceMock, times(1)).logEventNoRequest("OnlineTestInvitationEmailSent", auditDetailsWithEmail)
@@ -197,12 +171,13 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
     "issue one email for invites to SJQ and BQ tests for non GIS candidates" in new SuccessfulTestInviteFixture {
       when(otRepositoryMock.getPhase1TestProfile(any[String])).thenReturn(Future.successful(Some(phase1TestProfile)))
-      val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingWithNoTimeAdjustments)
+      val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
       result.futureValue mustBe (())
 
-      verify(emailClientMock, times(1)).sendOnlineTestInvitation(eqTo(EmailContactDetails), eqTo(PreferredName), eqTo(ExpirationDate))(
-        any[HeaderCarrier]
-      )
+      verify(emailClientMock, times(1)).sendOnlineTestInvitation(
+        eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate)
+      )(any[HeaderCarrier])
+
       verify(auditServiceMock, times(2)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
       verify(auditServiceMock, times(2)).logEventNoRequest("UserInvitedToOnlineTest", auditDetails)
       verify(auditServiceMock, times(1)).logEventNoRequest("OnlineTestInvitationEmailSent", auditDetailsWithEmail)
@@ -213,21 +188,22 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
     "fail if registration fails" in new OnlineTest {
       when(cubiksGatewayClientMock.registerApplicant(any[RegisterApplicant])(any[HeaderCarrier])).
-        thenReturn(Future.failed(new ConnectorException(ErrorMessage)))
+        thenReturn(Future.failed(new ConnectorException(connectorErrorMessage)))
 
-      val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingWithNoTimeAdjustments)
+      val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
       result.failed.futureValue mustBe a[ConnectorException]
 
       verify(auditServiceMock, times(0)).logEventNoRequest(any[String], any[Map[String, String]])
     }
+
     "fail and audit 'UserRegisteredForOnlineTest' if invitation fails" in new OnlineTest {
       when(cubiksGatewayClientMock.registerApplicant(any[RegisterApplicant])(any[HeaderCarrier]))
         .thenReturn(Future.successful(registration))
       when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier])).thenReturn(
-        Future.failed(new ConnectorException(ErrorMessage))
+        Future.failed(new ConnectorException(connectorErrorMessage))
       )
 
-      val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingWithNoTimeAdjustments)
+      val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
       result.failed.futureValue mustBe a[ConnectorException]
 
       verify(auditServiceMock, times(2)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
@@ -239,10 +215,10 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
           .thenReturn(Future.successful(registration))
         when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
           .thenReturn(Future.successful(invitation))
-        when(cdRepositoryMock.find(UserId))
+        when(cdRepositoryMock.find("userId"))
           .thenReturn(Future.failed(new Exception))
 
-        val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingWithNoTimeAdjustments)
+        val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
         result.failed.futureValue mustBe an[Exception]
 
         verify(auditServiceMock, times(2)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
@@ -255,13 +231,15 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
           .thenReturn(Future.successful(registration))
         when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
           .thenReturn(Future.successful(invitation))
-        when(cdRepositoryMock.find(UserId))
+        when(cdRepositoryMock.find("userId"))
           .thenReturn(Future.successful(contactDetails))
-        when(emailClientMock.sendOnlineTestInvitation(eqTo(EmailContactDetails), eqTo(PreferredName), eqTo(ExpirationDate))(
-          any[HeaderCarrier]
-        )).thenReturn(Future.failed(new Exception))
 
-        val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingWithNoTimeAdjustments)
+        when(emailClientMock.sendOnlineTestInvitation(
+          eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate)
+        )(any[HeaderCarrier]))
+          .thenReturn(Future.failed(new Exception))
+
+        val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
         result.failed.futureValue mustBe an[Exception]
 
         verify(auditServiceMock, times(2)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
@@ -275,25 +253,27 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
           .thenReturn(Future.successful(registration))
         when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
           .thenReturn(Future.successful(invitation))
-        when(cdRepositoryMock.find(UserId)).thenReturn(Future.successful(contactDetails))
-        when(emailClientMock.sendOnlineTestInvitation(eqTo(EmailContactDetails), eqTo(PreferredName), eqTo(ExpirationDate))(
-          any[HeaderCarrier]
-        )).thenReturn(Future.successful(()))
+        when(cdRepositoryMock.find("userId")).thenReturn(Future.successful(contactDetails))
+        when(emailClientMock.sendOnlineTestInvitation(
+          eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate))(any[HeaderCarrier])
+        ).thenReturn(Future.successful(()))
 
-        when(otRepositoryMock.insertOrUpdatePhase1TestGroup(ApplicationId, phase1TestProfile))
-          .thenReturn(Future.failed(new Exception))
-        when(trRepositoryMock.remove(ApplicationId)).thenReturn(Future.successful(()))
 
-        val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingWithNoTimeAdjustments)
-        result.failed.futureValue mustBe an[Exception]
+      when(otRepositoryMock.insertOrUpdatePhase1TestGroup("appId", phase1TestProfile))
+        .thenReturn(Future.failed(new Exception))
+      when(trRepositoryMock.remove("appId")).thenReturn(Future.successful(()))
 
-        verify(emailClientMock, times(0)).sendOnlineTestInvitation(any[String], any[String], any[DateTime])(
-          any[HeaderCarrier]
-        )
-        verify(auditServiceMock, times(2)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
-        verify(auditServiceMock, times(2)).logEventNoRequest("UserInvitedToOnlineTest", auditDetails)
-        verify(auditServiceMock, times(4)).logEventNoRequest(any[String], any[Map[String, String]])
-      }
+      val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
+      result.failed.futureValue mustBe an[Exception]
+
+      verify(emailClientMock, times(0)).sendOnlineTestInvitation(any[String], any[String], any[DateTime])(
+        any[HeaderCarrier]
+      )
+      verify(auditServiceMock, times(2)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
+      verify(auditServiceMock, times(2)).logEventNoRequest("UserInvitedToOnlineTest", auditDetails)
+      verify(auditServiceMock, times(4)).logEventNoRequest(any[String], any[Map[String, String]])
+    }
+
     "audit 'OnlineTestInvitationProcessComplete' on success" in new OnlineTest {
       when(otRepositoryMock.getPhase1TestProfile(any[String])).thenReturn(Future.successful(Some(phase1TestProfile)))
       when(cubiksGatewayClientMock.registerApplicant(eqTo(registerApplicant))(any[HeaderCarrier]))
@@ -301,41 +281,27 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
       when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
         .thenReturn(Future.successful(invitation))
       when(cdRepositoryMock.find(any[String])).thenReturn(Future.successful(contactDetails))
-      when(emailClientMock.sendOnlineTestInvitation(eqTo(EmailContactDetails), eqTo(PreferredName), eqTo(ExpirationDate))(
+      when(emailClientMock.sendOnlineTestInvitation(
+        eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate))(
         any[HeaderCarrier]
       )).thenReturn(Future.successful(()))
       when(otRepositoryMock.insertOrUpdatePhase1TestGroup(any[String], any[Phase1TestProfile]))
         .thenReturn(Future.successful(()))
       when(trRepositoryMock.remove(any[String])).thenReturn(Future.successful(()))
 
-      val result = onlineTestService.registerAndInviteForTestGroup(applicationForOnlineTestingWithNoTimeAdjustments)
+      val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
       result.futureValue mustBe (())
 
-      verify(emailClientMock, times(1)).sendOnlineTestInvitation(eqTo(EmailContactDetails), eqTo(PreferredName), eqTo(ExpirationDate))(
-        any[HeaderCarrier]
-      )
+      verify(emailClientMock, times(1)).sendOnlineTestInvitation(
+        eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate)
+      )(any[HeaderCarrier])
+
       verify(auditServiceMock, times(2)).logEventNoRequest("UserRegisteredForOnlineTest", auditDetails)
       verify(auditServiceMock, times(2)).logEventNoRequest("UserInvitedToOnlineTest", auditDetails)
       verify(auditServiceMock, times(1)).logEventNoRequest("OnlineTestInvitationEmailSent", auditDetailsWithEmail)
       verify(auditServiceMock, times(1)).logEventNoRequest("OnlineTestInvitationProcessComplete", auditDetails)
       verify(auditServiceMock, times(1)).logEventNoRequest("OnlineTestInvited", auditDetails)
       verify(auditServiceMock, times(7)).logEventNoRequest(any[String], any[Map[String, String]])
-    }
-  }
-
-  "get time adjustments" should {
-    "return None if application's time adjustments are empty" in new OnlineTest {
-      onlineTestService.getTimeAdjustments(applicationForOnlineTestingWithNoTimeAdjustments) mustBe (None)
-    }
-
-    "return Time Adjustments if application's time adjustments are not empty" in new OnlineTest {
-      val result = onlineTestService.getTimeAdjustments(applicationForOnlineTestingWithTimeAdjustments)
-      result.isDefined mustBe (true)
-      result.get.numericalSectionId mustBe (NumericalSectionId)
-      result.get.numericalAbsoluteTime mustBe (7)
-      result.get.verbalAndNumericalAssessmentId mustBe (VerbalAndNumericalAssessmentId)
-      result.get.verbalSectionId mustBe (VerbalSectionId)
-      result.get.verbalAbsoluteTime mustBe (7)
     }
   }
 
@@ -363,68 +329,44 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
   }
 
   "build invite application" should {
-    "return an InviteApplication with no time adjustments if gis and application has no time adjustments" in new OnlineTest {
-      val result = onlineTestService.buildInviteApplication(applicationForOnlineTestingGisWithNoTimeAdjustments,
-        "token", CubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("sjq"))
+    "return an InviteApplication for a GIS candidate" in new OnlineTest {
+      val result = onlineTestService.buildInviteApplication(
+        onlineTestApplication.copy(guaranteedInterview = true),
+        "token", cubiksUserId, sjqScheduleId
+      )
 
-      result mustBe inviteApplicantGisWithNoTimeAdjustments.copy(
+      result mustBe inviteApplicant.copy(
         scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/complete/token"
       )
     }
 
-    "return an InviteApplication with no time adjustments if gis and application has time adjustments" in new OnlineTest {
-      val result = onlineTestService.buildInviteApplication(applicationForOnlineTestingGisWithTimeAdjustments,
-        "token", CubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("sjq"))
+    "return an InviteApplication for a non GIS candidate" in new OnlineTest {
+      val sjqInvite = onlineTestService.buildInviteApplication(onlineTestApplication,
+        "token", cubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("sjq"))
 
-      result mustBe inviteApplicantGisWithNoTimeAdjustments.copy(
-        scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/complete/token"
-      )
-    }
-
-    "return an InviteApplication with no time adjustments if no gis and application has no time adjustments" in new OnlineTest {
-      val sjqInvite = onlineTestService.buildInviteApplication(applicationForOnlineTestingWithNoTimeAdjustments,
-        "token", CubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("sjq"))
-
-      sjqInvite mustBe inviteApplicantNoGisWithNoTimeAdjustments.copy(
-        scheduleID = testGatewayConfig.onlineTestConfig.scheduleIds("sjq"),
+      sjqInvite mustBe inviteApplicant.copy(
+        scheduleID = sjqScheduleId,
         scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/continue/token"
       )
 
-      val bqInvite = onlineTestService.buildInviteApplication(applicationForOnlineTestingWithNoTimeAdjustments,
-        "token", CubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("bq"))
+      val bqInvite = onlineTestService.buildInviteApplication(onlineTestApplication,
+        "token", cubiksUserId, bqScheduleId)
 
-      bqInvite mustBe inviteApplicantNoGisWithNoTimeAdjustments.copy(
-        scheduleID = testGatewayConfig.onlineTestConfig.scheduleIds("bq"),
+      bqInvite mustBe inviteApplicant.copy(
+        scheduleID = bqScheduleId,
         scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/complete/token"
       )
     }
 
-    "return an InviteApplication with time adjustments if no gis and application has time adjustments" in new OnlineTest {
-      val sjqInvite = onlineTestService.buildInviteApplication(applicationForOnlineTestingWithTimeAdjustments,
-        "token", CubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("sjq"))
-
-      sjqInvite mustBe inviteApplicantNoGisWithTimeAdjustments.copy(
-        scheduleID = testGatewayConfig.onlineTestConfig.scheduleIds("sjq"),
-        scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/continue/token"
-      )
-
-      val bqInvite = onlineTestService.buildInviteApplication(applicationForOnlineTestingWithTimeAdjustments,
-        "token", CubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("bq"))
-
-      bqInvite mustBe inviteApplicantNoGisWithTimeAdjustments.copy(
-        scheduleID = testGatewayConfig.onlineTestConfig.scheduleIds("bq"),
-        scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/complete/token"
-      )
-    }
   }
 
   "mark as started" should {
     "change progress to started" in new OnlineTest {
       when(otRepositoryMock.insertOrUpdatePhase1TestGroup(any[String], any[Phase1TestProfile])).thenReturn(Future.successful())
-      when(otRepositoryMock.getPhase1TestProfileByCubiksId(CubiksUserId))
+      when(otRepositoryMock.getPhase1TestProfileByCubiksId(cubiksUserId))
         .thenReturn(Future.successful(Phase1TestProfileWithAppId("appId123", phase1TestProfile)))
       when(otRepositoryMock.updateProgressStatus("appId123", ProgressStatuses.PHASE1_TESTS_STARTED)).thenReturn(Future.successful())
-      onlineTestService.markAsStarted(CubiksUserId).futureValue
+      onlineTestService.markAsStarted(cubiksUserId).futureValue
 
       verify(otRepositoryMock).updateProgressStatus("appId123", ProgressStatuses.PHASE1_TESTS_STARTED)
     }
@@ -434,10 +376,10 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     "change progress to completed if there are all tests completed" in new OnlineTest {
       when(otRepositoryMock.insertOrUpdatePhase1TestGroup(any[String], any[Phase1TestProfile])).thenReturn(Future.successful())
       val phase1Tests = phase1TestProfile.copy(tests = phase1TestProfile.tests.map(t => t.copy(completedDateTime = Some(DateTime.now()))))
-      when(otRepositoryMock.getPhase1TestProfileByCubiksId(CubiksUserId))
+      when(otRepositoryMock.getPhase1TestProfileByCubiksId(cubiksUserId))
         .thenReturn(Future.successful(Phase1TestProfileWithAppId("appId123", phase1Tests)))
       when(otRepositoryMock.updateProgressStatus("appId123", ProgressStatuses.PHASE1_TESTS_COMPLETED)).thenReturn(Future.successful())
-      onlineTestService.markAsCompleted(CubiksUserId).futureValue
+      onlineTestService.markAsCompleted(cubiksUserId).futureValue
 
       verify(otRepositoryMock).updateProgressStatus("appId123", ProgressStatuses.PHASE1_TESTS_COMPLETED)
     }
@@ -457,8 +399,8 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     val tokenFactoryMock = mock[UUIDFactory]
     val onlineTestInvitationDateFactoryMock = mock[DateTimeFactory]
 
-    when(tokenFactoryMock.generateUUID()).thenReturn(Token)
-    when(onlineTestInvitationDateFactoryMock.nowLocalTimeZone).thenReturn(InvitationDate)
+    when(tokenFactoryMock.generateUUID()).thenReturn(token)
+    when(onlineTestInvitationDateFactoryMock.nowLocalTimeZone).thenReturn(invitationDate)
 
     val onlineTestService = new OnlineTestService {
       val appRepository = appRepositoryMock
@@ -482,7 +424,8 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
       .thenReturn(Future.successful(invitation))
     when(cdRepositoryMock.find(any[String])).thenReturn(Future.successful(contactDetails))
-    when(emailClientMock.sendOnlineTestInvitation(eqTo(EmailContactDetails), eqTo(PreferredName), eqTo(ExpirationDate))(
+    when(emailClientMock.sendOnlineTestInvitation(
+      eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate))(
       any[HeaderCarrier]
     )).thenReturn(Future.successful(()))
     when(otRepositoryMock.insertOrUpdatePhase1TestGroup(any[String], any[Phase1TestProfile])).thenReturn(Future.successful(()))

--- a/test/services/onlinetesting/OnlineTestServiceSpec.scala
+++ b/test/services/onlinetesting/OnlineTestServiceSpec.scala
@@ -48,8 +48,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
   val testGatewayConfig = CubiksGatewayConfig(
     "",
-    CubiksOnlineTestConfig(phaseName = "phase",
-      expiryTimeInDays = 7,
+    Phase1TestsConfig(expiryTimeInDays = 7,
       scheduleIds = Map("sjq" -> 16196, "bq" -> 16194),
       List("sjq", "bq"),
       List("sjq")
@@ -61,8 +60,8 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     emailDomain = "test.com"
   )
 
-  val sjqScheduleId =testGatewayConfig.onlineTestConfig.scheduleIds("sjq")
-  val bqScheduleId =testGatewayConfig.onlineTestConfig.scheduleIds("bq")
+  val sjqScheduleId =testGatewayConfig.phase1TestsConfig.scheduleIds("sjq")
+  val bqScheduleId =testGatewayConfig.phase1TestsConfig.scheduleIds("bq")
 
   val preferredName = "Preferred\tName"
   val preferredNameSanitized = "Preferred Name"
@@ -95,7 +94,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
   val invitationDate = DateTime.parse("2016-05-11")
   val expirationDate = invitationDate.plusDays(7)
-  val phase1Test = Phase1Test(scheduleId = testGatewayConfig.onlineTestConfig.scheduleIds("sjq"),
+  val phase1Test = Phase1Test(scheduleId = testGatewayConfig.phase1TestsConfig.scheduleIds("sjq"),
     usedForResults = true,
     cubiksUserId = cubiksUserId,
     token = token,
@@ -342,7 +341,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
     "return an InviteApplication for a non GIS candidate" in new OnlineTest {
       val sjqInvite = onlineTestService.buildInviteApplication(onlineTestApplication,
-        "token", cubiksUserId, testGatewayConfig.onlineTestConfig.scheduleIds("sjq"))
+        "token", cubiksUserId, testGatewayConfig.phase1TestsConfig.scheduleIds("sjq"))
 
       sjqInvite mustBe inviteApplicant.copy(
         scheduleID = sjqScheduleId,

--- a/test/services/onlinetesting/OnlineTestServiceSpec.scala
+++ b/test/services/onlinetesting/OnlineTestServiceSpec.scala
@@ -65,10 +65,11 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
   val preferredName = "Preferred\tName"
   val preferredNameSanitized = "Preferred Name"
+  val userId = "userId"
 
   val onlineTestApplication = OnlineTestApplication(applicationId = "appId",
     applicationStatus = ApplicationStatus.SUBMITTED,
-    userId = "userId",
+    userId = userId,
     guaranteedInterview = false,
     needsAdjustments = false,
     preferredName,
@@ -115,7 +116,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
   val emailContactDetails = "emailfjjfjdf@mailinator.com"
   val contactDetails = ContactDetails(Address("Aldwych road"), postcode, emailContactDetails, Some("111111"))
 
-  val auditDetails = Map("userId" -> "userId")
+  val auditDetails = Map("userId" -> userId)
   val auditDetailsWithEmail = auditDetails + ("email" -> emailContactDetails)
 
   val connectorErrorMessage = "Error in connector"
@@ -214,7 +215,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
           .thenReturn(Future.successful(registration))
         when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
           .thenReturn(Future.successful(invitation))
-        when(cdRepositoryMock.find("userId"))
+        when(cdRepositoryMock.find(userId))
           .thenReturn(Future.failed(new Exception))
 
         val result = onlineTestService.registerAndInviteForTestGroup(onlineTestApplication)
@@ -230,7 +231,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
           .thenReturn(Future.successful(registration))
         when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
           .thenReturn(Future.successful(invitation))
-        when(cdRepositoryMock.find("userId"))
+        when(cdRepositoryMock.find(userId))
           .thenReturn(Future.successful(contactDetails))
 
         when(emailClientMock.sendOnlineTestInvitation(
@@ -252,7 +253,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
           .thenReturn(Future.successful(registration))
         when(cubiksGatewayClientMock.inviteApplicant(any[InviteApplicant])(any[HeaderCarrier]))
           .thenReturn(Future.successful(invitation))
-        when(cdRepositoryMock.find("userId")).thenReturn(Future.successful(contactDetails))
+        when(cdRepositoryMock.find(userId)).thenReturn(Future.successful(contactDetails))
         when(emailClientMock.sendOnlineTestInvitation(
           eqTo(emailContactDetails), eqTo(preferredName), eqTo(expirationDate))(any[HeaderCarrier])
         ).thenReturn(Future.successful(()))
@@ -331,7 +332,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     "return an InviteApplication for a GIS candidate" in new OnlineTest {
       val result = onlineTestService.buildInviteApplication(
         onlineTestApplication.copy(guaranteedInterview = true),
-        "token", cubiksUserId, sjqScheduleId
+        token, cubiksUserId, sjqScheduleId
       )
 
       result mustBe inviteApplicant.copy(
@@ -341,7 +342,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
     "return an InviteApplication for a non GIS candidate" in new OnlineTest {
       val sjqInvite = onlineTestService.buildInviteApplication(onlineTestApplication,
-        "token", cubiksUserId, testGatewayConfig.phase1Tests.scheduleIds("sjq"))
+        token, cubiksUserId, testGatewayConfig.phase1Tests.scheduleIds("sjq"))
 
       sjqInvite mustBe inviteApplicant.copy(
         scheduleID = sjqScheduleId,
@@ -349,7 +350,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
       )
 
       val bqInvite = onlineTestService.buildInviteApplication(onlineTestApplication,
-        "token", cubiksUserId, bqScheduleId)
+        token, cubiksUserId, bqScheduleId)
 
       bqInvite mustBe inviteApplicant.copy(
         scheduleID = bqScheduleId,

--- a/test/services/onlinetesting/OnlineTestServiceSpec.scala
+++ b/test/services/onlinetesting/OnlineTestServiceSpec.scala
@@ -44,7 +44,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
   with PrivateMethodTester {
   implicit val ec: ExecutionContext = ExecutionContext.global
 
-  val scheduleCompletionBaseUrl = "http://localhost:9284/fset-fast-stream/online-tests/"
+  val scheduleCompletionBaseUrl = "http://localhost:9284/fset-fast-stream/online-tests/phase1"
 
   val testGatewayConfig = CubiksGatewayConfig(
     "",
@@ -336,7 +336,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
       )
 
       result mustBe inviteApplicant.copy(
-        scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/complete/token"
+        scheduleCompletionURL = s"$scheduleCompletionBaseUrl/complete/$token"
       )
     }
 
@@ -346,7 +346,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
       sjqInvite mustBe inviteApplicant.copy(
         scheduleID = sjqScheduleId,
-        scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/continue/token"
+        scheduleCompletionURL = s"$scheduleCompletionBaseUrl/continue/$token"
       )
 
       val bqInvite = onlineTestService.buildInviteApplication(onlineTestApplication,
@@ -354,7 +354,7 @@ class OnlineTestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
       bqInvite mustBe inviteApplicant.copy(
         scheduleID = bqScheduleId,
-        scheduleCompletionURL = s"${testGatewayConfig.candidateAppUrl}/fset-fast-stream/online-tests/complete/token"
+        scheduleCompletionURL = s"$scheduleCompletionBaseUrl/complete/$token"
       )
     }
 


### PR DESCRIPTION
Provide Cubiks with different schedule completion URLs depending on GIS status and schedule Id so we can render different status pages.
