### PR TITLE
Change mongo query for results ready scheduler.

### DIFF
--- a/app/repositories/onlinetesting/Phase1TestRepository.scala
+++ b/app/repositories/onlinetesting/Phase1TestRepository.scala
@@ -158,12 +158,24 @@ class Phase1TestMongoRepository(dateTime: DateTimeFactory)(implicit mongo: () =>
   }
 
   def nextTestGroupWithReportReady: Future[Option[Phase1TestWithUserIds]] = {
+
+    /*db.getCollection('application').find(
+      {"$and" : [
+         {"applicationStatus" : "PHASE1_TESTS"},
+         {"progress-status.PHASE1_TESTS_COMPLETED" : true},
+         {"progress-status.PHASE1_TESTS_RESULTS_RECEVIED" : {"$ne" : true}},
+         {"testGroups.PHASE1.tests" : {"$elemMatch" : {"resultsReadyToDownload" : true, "testResult" : {"$exists" : false}}}}
+       ]}
+    ) */
+
     val query = BSONDocument("$and" -> BSONArray(
       BSONDocument("applicationStatus" -> ApplicationStatus.PHASE1_TESTS),
-      BSONDocument(s"progress-status.${ProgressStatuses.PHASE1_TESTS_RESULTS_READY}" -> true),
-      BSONDocument(s"progress-status.${ProgressStatuses.PHASE1_TESTS_RESULTS_RECEIVED}" ->
-        BSONDocument("$ne" -> true)
-      )
+      BSONDocument(s"progress-status.${ProgressStatuses.PHASE1_TESTS_COMPLETED}" -> true),
+      BSONDocument(s"progress-status.${ProgressStatuses.PHASE1_TESTS_RESULTS_RECEIVED}" -> BSONDocument("$ne" -> true)),
+      BSONDocument("testGroups.PHASE1.tests" ->
+        BSONDocument("$elemMatch" -> BSONArray(BSONDocument("resultsReadyToDownload" -> true),
+          BSONDocument("testResult" -> BSONDocument("$exists" -> false)))
+      ))
     ))
 
     implicit val reader = bsonReader { doc =>

--- a/app/repositories/onlinetesting/Phase1TestRepository.scala
+++ b/app/repositories/onlinetesting/Phase1TestRepository.scala
@@ -26,6 +26,7 @@ import model.persisted.{ ExpiringOnlineTest, NotificationExpiringOnlineTest, Pha
 import model.ProgressStatuses.{ PHASE1_TESTS_INVITED, _ }
 import model.{ ApplicationStatus, ProgressStatuses, ReminderNotice }
 import play.api.Logger
+import play.api.libs.json.Json
 import reactivemongo.api.DB
 import reactivemongo.bson._
 import uk.gov.hmrc.mongo.ReactiveRepository
@@ -173,9 +174,8 @@ class Phase1TestMongoRepository(dateTime: DateTimeFactory)(implicit mongo: () =>
       BSONDocument(s"progress-status.${ProgressStatuses.PHASE1_TESTS_COMPLETED}" -> true),
       BSONDocument(s"progress-status.${ProgressStatuses.PHASE1_TESTS_RESULTS_RECEIVED}" -> BSONDocument("$ne" -> true)),
       BSONDocument("testGroups.PHASE1.tests" ->
-        BSONDocument("$elemMatch" -> BSONArray(BSONDocument("resultsReadyToDownload" -> true),
-          BSONDocument("testResult" -> BSONDocument("$exists" -> false)))
-      ))
+        BSONDocument("$elemMatch" -> BSONDocument("resultsReadyToDownload" -> true, "testResult" -> BSONDocument("$exists" -> false)))
+      )
     ))
 
     implicit val reader = bsonReader { doc =>

--- a/it/repositories/onlinetesting/Phase1TestRepositorySpec.scala
+++ b/it/repositories/onlinetesting/Phase1TestRepositorySpec.scala
@@ -28,6 +28,7 @@ import model.{ ApplicationStatus, ProgressStatuses, ReminderNotice, persisted }
 import org.joda.time.{ DateTime, DateTimeZone }
 import reactivemongo.bson.BSONDocument
 import testkit.MongoRepositorySpec
+import play.api.Logger
 
 class Phase1TestRepositorySpec extends ApplicationDataFixture with MongoRepositorySpec {
   import TextFixture._
@@ -157,7 +158,7 @@ class Phase1TestRepositorySpec extends ApplicationDataFixture with MongoReposito
 
     "return a test group if only one report is ready to download" in {
 
-      val profile = testProfileWithAppId.phase1TestProfile.copy(tests = List(phase1Test.copy(resultsReadyToDownload = false), phase1Test))
+      val profile = testProfileWithAppId.phase1TestProfile.copy(tests = List(phase1Test, phase1Test.copy(resultsReadyToDownload = true)))
 
       createApplicationWithAllFields("userId2", "appId2", "frameworkId", "PHASE1_TESTS", needsAdjustment = false,
         adjustmentsConfirmed = false, timeExtensionAdjustments = false, fastPassApplicable = false,
@@ -167,7 +168,7 @@ class Phase1TestRepositorySpec extends ApplicationDataFixture with MongoReposito
 
       val phase1TestResultsReady = phase1TestRepo.nextTestGroupWithReportReady.futureValue
       phase1TestResultsReady.isDefined mustBe true
-      phase1TestResultsReady.get mustBe profile
+      phase1TestResultsReady.get mustBe Phase1TestWithUserIds("appId2", "userId2", profile)
     }
 
     "correctly update a test group with results" in {

--- a/test/services/onlinetesting/Phase1TestServiceSpec.scala
+++ b/test/services/onlinetesting/Phase1TestServiceSpec.scala
@@ -140,6 +140,22 @@ class Phase1TestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
 
   val connectorErrorMessage = "Error in connector"
 
+  val result = OnlineTestCommands.TestResult(status = "Completed",
+                                             norm = "some norm",
+                                             tScore = Some(23.9999d),
+                                             percentile = Some(22.4d),
+                                             raw = Some(66.9999d),
+                                             sten = Some(1.333d)
+  )
+
+  val savedResult = persisted.TestResult(status = "Completed",
+                                         norm = "some norm",
+                                         tScore = Some(23.9999d),
+                                         percentile = Some(22.4d),
+                                         raw = Some(66.9999d),
+                                         sten = Some(1.333d)
+  )
+
   "get online test" should {
     "return None if the application id does not exist" in new OnlineTest {
       when(otRepositoryMock.getTestGroup(any())).thenReturn(Future.successful(None))
@@ -348,7 +364,7 @@ class Phase1TestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
   }
 
   "build invite application" should {
-    "return an InviteApplication for a GIS candidate" in new OnlineTest {
+     "return an InviteApplication for a GIS candidate" in new OnlineTest {
       val result = phase1TestService.buildInviteApplication(
         onlineTestApplication.copy(guaranteedInterview = true),
         token, cubiksUserId, sjqScheduleId
@@ -472,12 +488,6 @@ class Phase1TestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
   }
 
   "retrieve phase 1 test report" should {
-    "return an exception if no report Id is set" in new OnlineTest {
-      an[Exception] must be thrownBy phase1TestService.retrieveTestResult(Phase1TestWithUserIds(
-        "appId", "userId", phase1TestProfile
-      ))
-    }
-
     "return an exception if there is an error retrieving one of the reports" in new OnlineTest {
       val failedTest = phase1Test.copy(scheduleId = 555, reportId = Some(2))
       val successfulTest = phase1Test.copy(scheduleId = 444, reportId = Some(1))
@@ -499,26 +509,49 @@ class Phase1TestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
       ))
     }
 
-    "save a phase1 report for a candidate" in new OnlineTest {
+    "save a phase1 report for a candidate and update progress status" in new OnlineTest {
+
+      val test = phase1Test.copy(reportId = Some(123), resultsReadyToDownload = true)
+      val testProfile = phase1TestProfile.copy(tests = List(test))
+
       when(cubiksGatewayClientMock.downloadXmlReport(any[Int])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(OnlineTestCommands.TestResult(status = "Completed",
-          norm = "some norm",
-          tScore = Some(23.9999d),
-          percentile = Some(22.4d),
-          raw = Some(66.9999d),
-          sten = Some(1.333d)
-        )))
+        .thenReturn(Future.successful(result))
 
       when(otRepositoryMock.insertPhase1TestResult(any[String], any[CubiksTest], any[persisted.TestResult]))
         .thenReturn(Future.successful(()))
       when(otRepositoryMock.updateProgressStatus(any[String], any[ProgressStatus]))
         .thenReturn(Future.successful(()))
+      when(otRepositoryMock.getTestGroup(any[String])).thenReturn(Future.successful(Some(testProfile.copy(tests = List(test.copy(testResult = Some(savedResult)))))))
 
-      val result = phase1TestService.retrieveTestResult(Phase1TestWithUserIds(
-        "appId", "userId", phase1TestProfile.copy(tests = List(phase1Test.copy(reportId = Some(123))))
+      phase1TestService.retrieveTestResult(Phase1TestWithUserIds(
+        "appId", "userId", testProfile
+      )).futureValue
+
+      verify(auditServiceMock, times(2)).logEventNoRequest(any[String], any[Map[String, String]])
+      verify(otRepositoryMock).updateProgressStatus(any[String], any[ProgressStatus])
+    }
+
+    "save a phase1 report for a candidate and not update progress status" in new OnlineTest {
+
+      val testReady = phase1Test.copy(reportId = Some(123), resultsReadyToDownload = true)
+      val testNotReady = phase1Test.copy(reportId = None, resultsReadyToDownload = false)
+      val testProfile = phase1TestProfile.copy(tests = List(testReady, testNotReady))
+
+      when(cubiksGatewayClientMock.downloadXmlReport(any[Int])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(result))
+
+      when(otRepositoryMock.insertPhase1TestResult(any[String], any[CubiksTest], any[persisted.TestResult]))
+        .thenReturn(Future.successful(()))
+      when(otRepositoryMock.updateProgressStatus(any[String], any[ProgressStatus]))
+        .thenReturn(Future.successful(()))
+      when(otRepositoryMock.getTestGroup(any[String])).thenReturn(Future.successful(Some(testProfile.copy(tests = List(testReady.copy(testResult = Some(savedResult)), testNotReady)))))
+
+      phase1TestService.retrieveTestResult(Phase1TestWithUserIds(
+        "appId", "userId", testProfile
       )).futureValue
 
       verify(auditServiceMock, times(1)).logEventNoRequest(any[String], any[Map[String, String]])
+      verify(otRepositoryMock, times(0)).updateProgressStatus(any[String], any[ProgressStatus])
     }
   }
 
@@ -532,7 +565,7 @@ class Phase1TestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
     val trRepositoryMock = mock[TestReportRepository]
     val cubiksGatewayClientMock = mock[CubiksGatewayClient]
     val emailClientMock = mock[CSREmailClient]
-    var auditServiceMock = mock[AuditService]
+    val auditServiceMock = mock[AuditService]
     val tokenFactoryMock = mock[UUIDFactory]
     val onlineTestInvitationDateFactoryMock = mock[DateTimeFactory]
     val eventServiceMock = mock[EventService]


### PR DESCRIPTION
Check the resultsReadyToDownload flag and whether we already have tests saved or not when selecting candidates for the results scheduler.
If we have all the results for active tests then set the progress status to PHASE1_TESTS_RESULTS_RECEIVED.