### PR TITLE
Rarely when using live-launchpad integration (i.e. a niche case) the …

### DIFF
--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -78,7 +78,7 @@ trait TestDataGeneratorService {
       parNumbers.map {
         candidateGenerationId =>
           val fut = generatorForStatus.generate(candidateGenerationId, generatorConfig)
-          Await.result(fut, 5 seconds)
+          Await.result(fut, 10 seconds)
       }.toList
     }
   }


### PR DESCRIPTION
…5 second timeout is hit, change to 10 to avoid this