### PR TITLE
Add test to check that phase 2 results and progress statuses aren't m…

### DIFF
--- a/app/services/onlinetesting/Phase2TestService.scala
+++ b/app/services/onlinetesting/Phase2TestService.scala
@@ -418,7 +418,9 @@ trait Phase2TestService extends OnlineTestService with Phase2TestConcern with Sc
       _ <- insertTests(eventualTestResults)
       _ <- maybeUpdateProgressStatus(testProfile.applicationId)
     } yield {
-      audit(s"ResultsRetrievedForSchedule", testProfile.applicationId)
+      eventualTestResults.foreach { _ =>
+        audit(s"ResultsRetrievedForSchedule", testProfile.applicationId)
+      }
     }
   }
 }

--- a/test/services/onlinetesting/Phase1TestServiceSpec.scala
+++ b/test/services/onlinetesting/Phase1TestServiceSpec.scala
@@ -541,6 +541,8 @@ class Phase1TestServiceSpec extends PlaySpec with BeforeAndAfterEach with Mockit
       val result = phase1TestService.retrieveTestResult(Phase1TestGroupWithUserIds(
         "appId", "userId", phase1TestProfile.copy(tests = List(successfulTest, failedTest))
       ))
+
+      result.failed.futureValue mustBe an[Exception]
     }
 
     "save a phase1 report for a candidate and update progress status" in new OnlineTest {

--- a/test/services/onlinetesting/Phase2TestServiceSpec.scala
+++ b/test/services/onlinetesting/Phase2TestServiceSpec.scala
@@ -99,7 +99,7 @@ class Phase2TestServiceSpec extends PlaySpec with MockitoSugar with ScalaFutures
       verify(phase2TestService.dataStoreEventHandlerMock, times(2)).handle(any[OnlineExerciseResultSent])(any[HeaderCarrier],
         any[RequestHeader])
       verify(auditServiceMock, times(2)).logEventNoRequest(eqTo("OnlineTestInvitationEmailSent"), any[Map[String, String]])
-      
+
       verify(otRepositoryMock, times(2)).insertCubiksTests(any[String], any[Phase2TestGroup])
       verify(otRepositoryMock, times(2)).markTestAsInactive(any[Int])
     }
@@ -299,23 +299,40 @@ class Phase2TestServiceSpec extends PlaySpec with MockitoSugar with ScalaFutures
   "retrieve phase 2 test report" should {
     "return an exception if there is an error retrieving one of the reports" in new Phase2TestServiceFixture {
       val failedTest = phase2Test.copy(scheduleId = 555, reportId = Some(2))
-      val successfulTest = phase2Test.copy(scheduleId = 444, reportId = Some(1))
-
-      when(cubiksGatewayClientMock.downloadXmlReport(eqTo(successfulTest.reportId.get)))
-        .thenReturn(Future.successful(OnlineTestCommands.TestResult(status = "Completed",
-          norm = "some norm",
-          tScore = Some(23.9999d),
-          percentile = Some(22.4d),
-          raw = Some(66.9999d),
-          sten = Some(1.333d)
-        )))
 
       when(cubiksGatewayClientMock.downloadXmlReport(eqTo(failedTest.reportId.get)))
         .thenReturn(Future.failed(new Exception))
 
       val result = phase2TestService.retrieveTestResult(Phase2TestGroupWithAppId(
-        "appId", phase2TestProfile.copy(tests = List(successfulTest, failedTest))
+        "appId", phase2TestProfile.copy(tests = List(failedTest))
       ))
+
+      result.failed.futureValue mustBe an[Exception]
+      verify(auditServiceMock, times(0)).logEventNoRequest(eqTo("ResultsRetrievedForSchedule"), any[Map[String, String]])
+      verify(auditServiceMock, times(0)).logEventNoRequest(eqTo(s"ProgressStatusSet${ProgressStatuses.PHASE2_TESTS_RESULTS_RECEIVED}"),
+        any[Map[String, String]])
+      verify(otRepositoryMock, times(0)).updateProgressStatus(any[String], any[ProgressStatus])
+      verify(otRepositoryMock, times(0)).insertTestResult(any[String], eqTo(failedTest), any[TestResult])
+    }
+
+    "Not update anything if the active test has no report Id" in new Phase2TestServiceFixture {
+      val usedTest = phase2Test.copy(usedForResults = true, reportId = None, resultsReadyToDownload = false)
+      val unusedTest = phase2Test.copy(usedForResults = false, reportId = Some(123), resultsReadyToDownload = true)
+      val testProfile = phase2TestProfile.copy(tests = List(usedTest, unusedTest))
+
+      when(otRepositoryMock.updateProgressStatus(any[String], any[ProgressStatus]))
+        .thenReturn(Future.successful(()))
+
+      phase2TestService.retrieveTestResult(Phase2TestGroupWithAppId(
+        "appId", testProfile
+      )).futureValue
+
+      verify(auditServiceMock, times(0)).logEventNoRequest(eqTo("ResultsRetrievedForSchedule"), any[Map[String, String]])
+      verify(auditServiceMock, times(0)).logEventNoRequest(eqTo(s"ProgressStatusSet${ProgressStatuses.PHASE2_TESTS_RESULTS_RECEIVED}"),
+        any[Map[String, String]])
+      verify(otRepositoryMock, times(0)).updateProgressStatus(any[String], any[ProgressStatus])
+      verify(otRepositoryMock, times(0)).insertTestResult(any[String], eqTo(usedTest), any[TestResult])
+      verify(otRepositoryMock, times(0)).insertTestResult(any[String], eqTo(unusedTest), any[TestResult])
     }
 
     "save a phase2 report for a candidate and update progress status" in new Phase2TestServiceFixture {


### PR DESCRIPTION
…odified in mongo if there was no result to download in the first place.