### PR TITLE
fset-814 added expired test scenario

### DIFF
--- a/app/controllers/OnlineTestController.scala
+++ b/app/controllers/OnlineTestController.scala
@@ -133,8 +133,9 @@ trait OnlineTestController extends BaseController {
   def verifyAccessCode() = Action.async(parse.json) { implicit request =>
     withJsonBody[VerifyAccessCode] { verifyAccessCode =>
       phase2TestService.verifyAccessCode(verifyAccessCode.email, verifyAccessCode.accessCode).map {
-        case Success(invigilatedTestUrl) => Ok(Json.toJson(InvigilatedTestUrl(invigilatedTestUrl)))
-        case Failure(f: ExpiredTestForTokenException) => Forbidden
+        invigilatedTestUrl => Ok(Json.toJson(InvigilatedTestUrl(invigilatedTestUrl)))
+      }.recover {
+        case _: ExpiredTestForTokenException => Forbidden
         case _ => NotFound
       }
     }

--- a/app/model/Exceptions.scala
+++ b/app/model/Exceptions.scala
@@ -87,6 +87,10 @@ object Exceptions {
   case class CannotUpdateAdjustmentsComment(applicationId: String) extends Exception(applicationId)
 
   case class CannotRemoveAdjustmentsComment(applicationId: String) extends Exception(applicationId)
+
+  case class InvalidTokenException(m: String) extends Exception(m)
+
+  case class ExpiredTestForTokenException(m: String) extends Exception(m)
 }
 
 // scalastyle:on number.of.methods

--- a/app/services/onlinetesting/Phase2TestService.scala
+++ b/app/services/onlinetesting/Phase2TestService.scala
@@ -96,14 +96,11 @@ trait Phase2TestService extends OnlineTestService with Phase2TestConcern with Sc
     }
   }
 
-  def verifyAccessCode(email: String, accessCode: String): Future[Try[String]] = {
-    (for {
-      userId <- cdRepository.findUserIdByEmail(email)
-      testGroupOpt <- phase2TestRepo.getTestGroupByUserId(userId)
-    } yield processEtrayToken(testGroupOpt, accessCode)) recover {
-      case e: ContactDetailsNotFoundForEmail => Failure(e)
-    }
-  }
+  def verifyAccessCode(email: String, accessCode: String): Future[String] = for {
+    userId <- cdRepository.findUserIdByEmail(email)
+    testGroupOpt <- phase2TestRepo.getTestGroupByUserId(userId)
+    testUrl <- Future.fromTry(processEtrayToken(testGroupOpt, accessCode))
+  } yield testUrl
 
   override def nextApplicationReadyForOnlineTesting: Future[List[OnlineTestApplication]] = {
     phase2TestRepo.nextApplicationsReadyForOnlineTesting

--- a/app/services/onlinetesting/Phase2TestService.scala
+++ b/app/services/onlinetesting/Phase2TestService.scala
@@ -23,7 +23,7 @@ import config.{ CubiksGatewayConfig, Phase2Schedule, Phase2TestsConfig }
 import connectors.ExchangeObjects._
 import connectors.{ AuthProviderClient, CubiksGatewayClient, Phase2OnlineTestEmailClient }
 import factories.{ DateTimeFactory, UUIDFactory }
-import model.Exceptions.{ ContactDetailsNotFoundForEmail, ApplicationNotFound, NotFoundException }
+import model.Exceptions._
 import model.OnlineTestCommands._
 import model.ProgressStatuses._
 import model.command.ProgressResponse
@@ -43,6 +43,7 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
 import scala.language.postfixOps
+import scala.util.{ Failure, Success, Try }
 
 object Phase2TestService extends Phase2TestService {
 
@@ -95,22 +96,12 @@ trait Phase2TestService extends OnlineTestService with Phase2TestConcern with Sc
     }
   }
 
-  def verifyAccessCode(email: String, accessCode: String): Future[Option[String]] = {
+  def verifyAccessCode(email: String, accessCode: String): Future[Try[String]] = {
     (for {
       userId <- cdRepository.findUserIdByEmail(email)
       testGroupOpt <- phase2TestRepo.getTestGroupByUserId(userId)
-    } yield {
-      testGroupOpt.flatMap { testGroup =>
-        val eTrayTest = testGroup.activeTests.head
-        val accessCodeOpt = eTrayTest.invigilatedAccessCode
-        if (accessCodeOpt.contains(accessCode)) {
-          Some(eTrayTest.testUrl)
-        } else {
-          None
-        }
-      }
-    }) recover {
-      case _: ContactDetailsNotFoundForEmail => None
+    } yield processEtrayToken(testGroupOpt, accessCode)) recover {
+      case e: ContactDetailsNotFoundForEmail => Failure(e)
     }
   }
 
@@ -222,6 +213,22 @@ trait Phase2TestService extends OnlineTestService with Phase2TestConcern with Sc
                 "scheduleName" -> s"$scheduleName")) ::
               Nil
           }).flatten
+        }
+      }
+    }
+  }
+
+  private def processEtrayToken(phase: Option[Phase2TestGroup], accessCode: String): Try[String] = {
+    phase.fold[Try[String]](Failure(new NotFoundException(Some("No Phase2TestGroup found")))){
+      group => {
+        val eTrayTest = group.activeTests.head
+        val accessCodeOpt = eTrayTest.invigilatedAccessCode
+        if(group.expirationDate.isBefore(dateTimeFactory.nowLocalTimeZone)) {
+          Failure(ExpiredTestForTokenException("Test expired for token"))
+        } else if (accessCodeOpt.contains(accessCode)) {
+          Success(eTrayTest.testUrl)
+        } else {
+          Failure(InvalidTokenException("Token mismatch"))
         }
       }
     }

--- a/test/controllers/OnlineTestsControllerSpec.scala
+++ b/test/controllers/OnlineTestsControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import model.ApplicationStatus
+import model.Exceptions.{ ContactDetailsNotFoundForEmail, ExpiredTestForTokenException }
 import model.OnlineTestCommands.OnlineTestApplication
 import model.command.{ InvigilatedTestUrl, ResetOnlineTest, VerifyAccessCode }
 import org.mockito.Matchers._
@@ -32,6 +33,7 @@ import testkit.UnitWithAppSpec
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
+import scala.util.{ Failure, Success }
 
 class OnlineTestsControllerSpec extends UnitWithAppSpec {
   val mockPhase1TestService = mock[Phase1TestService]
@@ -105,7 +107,7 @@ class OnlineTestsControllerSpec extends UnitWithAppSpec {
 
       val invigilatedTestUrl = "invigilated.test.url"
       when(mockPhase2TestService.verifyAccessCode(any[String], any[String]))
-        .thenReturn(Future.successful(Some(invigilatedTestUrl)))
+        .thenReturn(Future.successful(Success(invigilatedTestUrl)))
 
       val response = controller.verifyAccessCode()(fakeRequest)
       status(response) mustBe OK
@@ -120,11 +122,26 @@ class OnlineTestsControllerSpec extends UnitWithAppSpec {
 
       val json: JsValue = Json.parse(jsonString)
       val fakeRequest = verifyAccessCodeRequest(json)
+      val noUserFound = Future.successful(Failure(ContactDetailsNotFoundForEmail()))
 
-      when(mockPhase2TestService.verifyAccessCode(any[String], any[String])).thenReturn(Future.successful(None))
+      when(mockPhase2TestService.verifyAccessCode(any[String], any[String])).thenReturn(noUserFound)
 
       val response = controller.verifyAccessCode()(fakeRequest)
       status(response) mustBe NOT_FOUND
+    }
+
+    "return FORBIDDEN when the test is expired" in {
+      val verifyAccessCode = VerifyAccessCode(email = "test@email.com", accessCode = "ACCESS-CODE")
+      val jsonString = Json.toJson(verifyAccessCode).toString()
+
+      val json: JsValue = Json.parse(jsonString)
+      val fakeRequest = verifyAccessCodeRequest(json)
+      val tokenExpired = Future.successful(Failure(ExpiredTestForTokenException("")))
+
+      when(mockPhase2TestService.verifyAccessCode(any[String], any[String])).thenReturn(tokenExpired)
+
+      val response = controller.verifyAccessCode()(fakeRequest)
+      status(response) mustBe FORBIDDEN
     }
   }
 

--- a/test/controllers/OnlineTestsControllerSpec.scala
+++ b/test/controllers/OnlineTestsControllerSpec.scala
@@ -107,7 +107,7 @@ class OnlineTestsControllerSpec extends UnitWithAppSpec {
 
       val invigilatedTestUrl = "invigilated.test.url"
       when(mockPhase2TestService.verifyAccessCode(any[String], any[String]))
-        .thenReturn(Future.successful(Success(invigilatedTestUrl)))
+        .thenReturn(Future.successful(invigilatedTestUrl))
 
       val response = controller.verifyAccessCode()(fakeRequest)
       status(response) mustBe OK
@@ -122,7 +122,7 @@ class OnlineTestsControllerSpec extends UnitWithAppSpec {
 
       val json: JsValue = Json.parse(jsonString)
       val fakeRequest = verifyAccessCodeRequest(json)
-      val noUserFound = Future.successful(Failure(ContactDetailsNotFoundForEmail()))
+      val noUserFound = Future.failed(ContactDetailsNotFoundForEmail())
 
       when(mockPhase2TestService.verifyAccessCode(any[String], any[String])).thenReturn(noUserFound)
 
@@ -136,7 +136,7 @@ class OnlineTestsControllerSpec extends UnitWithAppSpec {
 
       val json: JsValue = Json.parse(jsonString)
       val fakeRequest = verifyAccessCodeRequest(json)
-      val tokenExpired = Future.successful(Failure(ExpiredTestForTokenException("")))
+      val tokenExpired = Future.failed(ExpiredTestForTokenException(""))
 
       when(mockPhase2TestService.verifyAccessCode(any[String], any[String])).thenReturn(tokenExpired)
 

--- a/test/services/onlinetesting/Phase2TestServiceSpec.scala
+++ b/test/services/onlinetesting/Phase2TestServiceSpec.scala
@@ -62,7 +62,7 @@ class Phase2TestServiceSpec extends UnitSpec with ExtendedTimeout {
       when(otRepositoryMock.getTestGroupByUserId(any[String])).thenReturn(Future.successful(Some(phase2TestGroup)))
 
       val result = phase2TestService.verifyAccessCode("test-email.com", accessCode).futureValue
-      result mustBe Success(authenticateUrl)
+      result mustBe authenticateUrl
     }
 
     "return a Failure if the access code does not match" in new Phase2TestServiceFixture {
@@ -72,15 +72,15 @@ class Phase2TestServiceSpec extends UnitSpec with ExtendedTimeout {
       val phase2TestGroup = Phase2TestGroup(expirationDate, List(phase2Test.copy(invigilatedAccessCode = Some(accessCode))))
       when(otRepositoryMock.getTestGroupByUserId(any[String])).thenReturn(Future.successful(Some(phase2TestGroup)))
 
-      val result = phase2TestService.verifyAccessCode("test-email.com", "I-DO-NOT-MATCH").futureValue
-      result mustBe Failure(InvalidTokenException("Token mismatch"))
+      val result = phase2TestService.verifyAccessCode("test-email.com", "I-DO-NOT-MATCH").failed.futureValue
+      result mustBe an[InvalidTokenException]
     }
 
     "return a Failure if the user cannot be located by email" in new Phase2TestServiceFixture {
       when(cdRepositoryMock.findUserIdByEmail(any[String])).thenReturn(Future.failed(ContactDetailsNotFoundForEmail()))
 
-      val result = phase2TestService.verifyAccessCode("test-email.com", "ANY-CODE").futureValue
-      result mustBe Failure(ContactDetailsNotFoundForEmail())
+      val result = phase2TestService.verifyAccessCode("test-email.com", "ANY-CODE").failed.futureValue
+      result mustBe an[ContactDetailsNotFoundForEmail]
     }
 
     "return A Failure if the test is Expired" in new Phase2TestServiceFixture {
@@ -90,8 +90,8 @@ class Phase2TestServiceSpec extends UnitSpec with ExtendedTimeout {
       val phase2TestGroup = Phase2TestGroup(expiredDate, List(phase2Test.copy(invigilatedAccessCode = Some(accessCode))))
       when(otRepositoryMock.getTestGroupByUserId(any[String])).thenReturn(Future.successful(Some(phase2TestGroup)))
 
-      val result = phase2TestService.verifyAccessCode("test-email.com", accessCode).futureValue
-      result mustBe Failure(ExpiredTestForTokenException("Test expired for token"))
+      val result = phase2TestService.verifyAccessCode("test-email.com", accessCode).failed.futureValue
+      result mustBe an[ExpiredTestForTokenException]
     }
   }
 


### PR DESCRIPTION
Added logic to take care of an expired phase 2 test for invigilated e-tray.
In this case a 403 will be returned back to the client, rather than the 404 for failed verification.