### PR TITLE
Mark application as results received when any results callbacks from launchpad are received

### DIFF
--- a/app/model/events/AuditEvents.scala
+++ b/app/model/events/AuditEvents.scala
@@ -56,6 +56,7 @@ object AuditEvents {
   case class VideoInterviewReset(seqDetails: (String, String)*) extends AuditEventNoRequest(seqDetails.toMap)
   case class VideoInterviewStarted(applicationId: String) extends AuditEventWithAppId(applicationId)
   case class VideoInterviewCompleted(applicationId: String) extends AuditEventWithAppId(applicationId)
+  case class VideoInterviewResultsReceived(applicationId: String) extends AuditEventWithAppId(applicationId)
   case class VideoInterviewTestExpiryReminder(mapDetails: Map[String, String]) extends AuditEvent(mapDetails)
 
   case class FixedProdData(mapDetails: Map[String, String]) extends AuditEventNoRequest(mapDetails)

--- a/app/model/events/DataStoreEvents.scala
+++ b/app/model/events/DataStoreEvents.scala
@@ -81,7 +81,7 @@ object DataStoreEvents {
   case class VideoInterviewCompleted(appId: String) extends DataStoreEventWithAppId
   case class VideoInterviewExtended(appId: String, createdByUser: String) extends DataStoreEventWithAppId
   case class VideoInterviewReset(appId: String, createdByUser: String) extends DataStoreEventWithAppId
-  case class VideoInterviewResultSent(appId: String) extends DataStoreEventWithAppId
+  case class VideoInterviewResultsReceived(appId: String) extends DataStoreEventWithAppId
   case class VideoInterviewExpiryReminder(appId: String) extends DataStoreEventWithAppId
 
   case class ManageAdjustmentsUpdated(appId: String) extends DataStoreEventWithAppId

--- a/app/services/onlinetesting/Phase3TestCallbackService.scala
+++ b/app/services/onlinetesting/Phase3TestCallbackService.scala
@@ -81,7 +81,10 @@ trait Phase3TestCallbackService {
     phase3TestRepo.appendCallback(callbackData.customInviteId, ViewBrandedVideoCallbackRequest.key, callbackData)
   }
 
-  def recordCallback(callbackData: ReviewedCallbackRequest): Future[Unit] = {
-    phase3TestRepo.appendCallback(callbackData.customInviteId, ReviewedCallbackRequest.key, callbackData)
+  def recordCallback(callbackData: ReviewedCallbackRequest)(implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = {
+    for {
+      _ <- phase3TestRepo.appendCallback(callbackData.customInviteId, ReviewedCallbackRequest.key, callbackData)
+      _ <- phase3TestService.markAsResultsReceived(callbackData.customInviteId)
+    } yield {}
   }
 }

--- a/app/services/onlinetesting/Phase3TestService.scala
+++ b/app/services/onlinetesting/Phase3TestService.scala
@@ -219,6 +219,19 @@ trait Phase3TestService extends OnlineTestService with Phase3TestConcern {
     }
   }
 
+  def markAsResultsReceived(launchpadInviteId: String)(implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = eventSink {
+    phase3TestRepo.getTestGroupByToken(launchpadInviteId).flatMap { test =>
+      for {
+        testGroup <- phase3TestRepo.getTestGroupByToken(launchpadInviteId)
+        _ <- phase3TestRepo.updateProgressStatus(testGroup.applicationId, ProgressStatuses.PHASE3_TESTS_RESULTS_RECEIVED)
+      } yield {
+        AuditEvents.VideoInterviewResultsReceived(testGroup.applicationId) ::
+          DataStoreEvents.VideoInterviewResultsReceived(testGroup.applicationId) ::
+          Nil
+      }
+    }
+  }
+
   def extendTestGroupExpiryTime(applicationId: String, extraDays: Int, actionTriggeredBy: String)
                                (implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = {
     val progressFut = appRepository.findProgress(applicationId)

--- a/test/controllers/LaunchpadTestsControllerSpec.scala
+++ b/test/controllers/LaunchpadTestsControllerSpec.scala
@@ -57,7 +57,8 @@ class LaunchpadTestsControllerSpec extends UnitWithAppSpec {
     when(mockPhase3TestCallbackService.recordCallback(any[ViewPracticeQuestionCallbackRequest]())).thenReturn(Future.successful(()))
     when(mockPhase3TestCallbackService.recordCallback(any[SetupProcessCallbackRequest]())).thenReturn(Future.successful(()))
     when(mockPhase3TestCallbackService.recordCallback(any[ViewBrandedVideoCallbackRequest]())).thenReturn(Future.successful(()))
-    when(mockPhase3TestCallbackService.recordCallback(any[ReviewedCallbackRequest]())).thenReturn(Future.successful(()))
+    when(mockPhase3TestCallbackService.recordCallback(any[ReviewedCallbackRequest]())
+    (any[HeaderCarrier](), any[RequestHeader]())).thenReturn(Future.successful(()))
 
     def controllerUnderTest = new LaunchpadTestsController {
       val phase3TestService = mockPhase3TestService
@@ -214,7 +215,7 @@ class LaunchpadTestsControllerSpec extends UnitWithAppSpec {
       val response = controllerUnderTest.reviewedCallback(sampleInviteId)(fakeRequest(sampleReviewedCallback))
       status(response) mustBe OK
 
-      verify(mockPhase3TestCallbackService, times(1)).recordCallback(eqTo(sampleReviewedCallback))
+      verify(mockPhase3TestCallbackService, times(1)).recordCallback(eqTo(sampleReviewedCallback))(any[HeaderCarrier](), any[RequestHeader]())
     }
   }
 }

--- a/test/services/onlinetesting/Phase3TestServiceSpec.scala
+++ b/test/services/onlinetesting/Phase3TestServiceSpec.scala
@@ -175,6 +175,17 @@ class Phase3TestServiceSpec extends UnitSpec with ExtendedTimeout {
     }
   }
 
+  "mark as results received" should {
+    "change progress to results received when any result set arrives" in new Phase3TestServiceFixture {
+      phase3TestServiceWithUnexpiredTestGroup.markAsResultsReceived(testInviteId).futureValue
+
+      verify(p3TestRepositoryMock).updateProgressStatus("appId123", ProgressStatuses.PHASE3_TESTS_RESULTS_RECEIVED)
+
+      verifyDataStoreEvents(1, "VideoInterviewResultsReceived")
+      verifyAuditEvents(1, "VideoInterviewResultsReceived")
+    }
+  }
+
   "extend a test group's expiry" should {
     "throw IllegalStateException when there is no test group" in new Phase3TestServiceFixture {
       phase3TestServiceNoTestGroup.extendTestGroupExpiryTime("a", 1, "1").failed.futureValue mustBe an[IllegalStateException]
@@ -372,7 +383,12 @@ class Phase3TestServiceSpec extends UnitSpec with ExtendedTimeout {
 
       // Mark as Complete
       when(p3TestRepositoryMock.updateProgressStatus("appId123", ProgressStatuses.PHASE3_TESTS_COMPLETED)).thenReturn(Future.successful(()))
-      when(p3TestRepositoryMock.updateTestCompletionTime(any[String], any[DateTime])).thenReturn(Future.successful(()))    }
+      when(p3TestRepositoryMock.updateTestCompletionTime(any[String], any[DateTime])).thenReturn(Future.successful(()))
+
+      // Mark as results received
+      when(p3TestRepositoryMock.updateProgressStatus("appId123", ProgressStatuses.PHASE3_TESTS_RESULTS_RECEIVED)).thenReturn(Future.successful(()))
+
+    }
 
     lazy val phase3TestServiceWithExpiredTestGroup = mockService {
       when(p3TestRepositoryMock.getTestGroup(any())).thenReturn(Future.successful(Some(


### PR DESCRIPTION
Good spot @satishkamatam - would you care to review?