### PR TITLE
FSET-814: bug fixing

### DIFF
--- a/app/model/command/testdata/GeneratorConfig.scala
+++ b/app/model/command/testdata/GeneratorConfig.scala
@@ -97,8 +97,8 @@ object Phase2TestData {
   def apply(o: model.exchange.testdata.Phase2TestDataRequest): Phase2TestData = {
     Phase2TestData(
       start = o.start.map(DateTime.parse),
-      expiry = o.start.map(DateTime.parse),
-      completion = o.start.map(DateTime.parse),
+      expiry = o.expiry.map(DateTime.parse),
+      completion = o.completion.map(DateTime.parse),
       tscore = o.tscore.map(_.toDouble)
     )
   }

--- a/app/services/onlinetesting/Phase2TestService.scala
+++ b/app/services/onlinetesting/Phase2TestService.scala
@@ -220,10 +220,13 @@ trait Phase2TestService extends OnlineTestService with Phase2TestConcern with Sc
       group => {
         val eTrayTest = group.activeTests.head
         val accessCodeOpt = eTrayTest.invigilatedAccessCode
-        if(group.expirationDate.isBefore(dateTimeFactory.nowLocalTimeZone)) {
-          Failure(ExpiredTestForTokenException("Test expired for token"))
-        } else if (accessCodeOpt.contains(accessCode)) {
-          Success(eTrayTest.testUrl)
+
+        if (accessCodeOpt.contains(accessCode)) {
+          if(group.expirationDate.isBefore(dateTimeFactory.nowLocalTimeZone)) {
+            Failure(ExpiredTestForTokenException("Test expired for token"))
+          } else {
+            Success(eTrayTest.testUrl)
+          }
         } else {
           Failure(InvalidTokenException("Token mismatch"))
         }


### PR DESCRIPTION
This PR is to fix a couple of minor issues:
1) there was a bug preventing us from setting start/expiry date for phase2 test via test generator
2) Regarding the invigilated e-tray token verification, the check for expired test is now done if, and only if, the access code is valid. This to avoid brute force attack meant to grab a valid user email.