### PR TITLE
FSET-1011: Parity Export: Add tests, audit, tweaks from live testing

### DIFF
--- a/app/connectors/paritygateway/ParityGatewayClient.scala
+++ b/app/connectors/paritygateway/ParityGatewayClient.scala
@@ -20,7 +20,7 @@ import config.MicroserviceAppConfig._
 import _root_.config.WSHttp
 import model.Exceptions.ConnectorException
 import play.api.http.Status._
-import play.api.libs.json.{ JsObject, JsValue }
+import play.api.libs.json.JsObject
 import uk.gov.hmrc.play.http.{ HeaderCarrier, HttpResponse }
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/app/model/events/AuditEvents.scala
+++ b/app/model/events/AuditEvents.scala
@@ -34,6 +34,7 @@ object AuditEvents {
   case class ApplicationSubmitted(applicationId: String) extends AuditEventWithAppId(applicationId)
   case class ApplicationWithdrawn(mapDetails: Map[String, String]) extends AuditEvent(mapDetails)
   case class ApplicationReadyForExport(mapDetails: Map[String, String]) extends AuditEvent(mapDetails)
+  case class ApplicationExported(seqDetails: (String, String)*) extends AuditEvent(seqDetails.toMap)
   case class ExpiredTestsExtended(mapDetails: Map[String, String]) extends AuditEventNoRequest(mapDetails)
   case class NonExpiredTestsExtended(mapDetails: Map[String, String]) extends AuditEventNoRequest(mapDetails)
   case class Phase1TestsReset(mapDetails: Map[String, String]) extends AuditEventNoRequest(mapDetails)

--- a/app/model/events/DataStoreEvents.scala
+++ b/app/model/events/DataStoreEvents.scala
@@ -60,6 +60,7 @@ object DataStoreEvents {
   case class ApplicationSubmitted(appId: String) extends DataStoreEventWithAppId
   case class ApplicationExpired(appId: String) extends DataStoreEventWithAppId
   case class ApplicationReadyForExport(appId: String) extends DataStoreEventWithAppId
+  case class ApplicationExported(appId: String) extends DataStoreEventWithAppId
   case class ApplicationExpiryReminder(appId: String) extends DataStoreEventWithAppId
   case class ApplicationWithdrawn(appId: String, createdByUser: String) extends DataStoreEventWithCreatedBy
 

--- a/app/scheduler/parity/ParityExportJob.scala
+++ b/app/scheduler/parity/ParityExportJob.scala
@@ -19,11 +19,12 @@ package scheduler.parity
 import java.util.concurrent.{ ArrayBlockingQueue, ThreadPoolExecutor, TimeUnit }
 
 import config.{ MicroserviceAppConfig, ScheduledJobConfig }
+import model.EmptyRequestHeader
 import play.api.Logger
 import scheduler.clustering.SingleInstanceScheduledJob
 import scheduler.onlinetesting.BasicJobConfig
-import services.application.ApplicationService
 import services.parity.ParityExportService
+import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -37,6 +38,9 @@ trait ParityExportJob extends SingleInstanceScheduledJob with ParityExportJobCon
   val parityExportJobConfig: ScheduledJobConfig
 
   override implicit val ec = ExecutionContext.fromExecutor(new ThreadPoolExecutor(2, 2, 180, TimeUnit.SECONDS, new ArrayBlockingQueue(4)))
+
+  implicit val blankHeaderCarrier = HeaderCarrier()
+  implicit val requestHeader = EmptyRequestHeader
 
   def tryExecute()(implicit ec: ExecutionContext): Future[Unit] = {
     service.nextApplicationsForExport(parityExportJobConfig.batchSize.getOrElse(1)).flatMap { applicationList =>

--- a/app/services/testdata/faker/DataFaker.scala
+++ b/app/services/testdata/faker/DataFaker.scala
@@ -622,7 +622,7 @@ object DataFaker {
 
     def yesNo = randOne(List("Yes", "No"))
 
-    def yesNoPreferNotToSay = randOne(List("Yes", "No", "I don't know/prefer not say"))
+    def yesNoPreferNotToSay = randOne(List("Yes", "No", "I don't know/prefer not to say"))
 
     def employeeOrSelf = randOne(List(
       "Employee",

--- a/it/repositories/CommonRepository.scala
+++ b/it/repositories/CommonRepository.scala
@@ -17,6 +17,7 @@ import reactivemongo.bson.BSONDocument
 import repositories.application.GeneralApplicationMongoRepository
 import repositories.assistancedetails.AssistanceDetailsMongoRepository
 import repositories.onlinetesting._
+import repositories.parity.ParityExportMongoRepository
 import repositories.passmarksettings._
 import services.GBTimeZoneService
 import testkit.MongoRepositorySpec
@@ -55,6 +56,7 @@ trait CommonRepository {
 
   def phase3PassMarkSettingRepo = new Phase3PassMarkSettingsMongoRepository()
 
+  def parityExportMongoRepo = new ParityExportMongoRepository(DateTimeFactory)
 
   implicit val now = DateTime.now().withZone(DateTimeZone.UTC)
 

--- a/it/repositories/MediaRepositorySpec.scala
+++ b/it/repositories/MediaRepositorySpec.scala
@@ -1,0 +1,39 @@
+package repositories
+
+import reactivemongo.bson.BSONDocument
+import reactivemongo.json.ImplicitBSONHandlers
+import model.persisted.Media
+import testkit.MongoRepositorySpec
+
+class MediaRepositorySpec extends MongoRepositorySpec {
+  import ImplicitBSONHandlers._
+
+  override val collectionName = "media"
+
+  def repository = new MediaMongoRepository()
+
+  "find media" should {
+    "return Some media when exists" in {
+      val testUserId = "userId1"
+      val testMediaStr = "Test Media"
+
+      repository.create(Media(
+        testUserId,
+        testMediaStr
+      )).futureValue
+
+      val fetchMedia = repository.find(testUserId).futureValue
+
+      fetchMedia must not be empty
+      fetchMedia.get mustBe Media(testUserId, testMediaStr)
+    }
+
+    "Return no media when does not exist" in {
+      val fetchMedia = repository.find("randomUserId").futureValue
+
+      fetchMedia mustBe empty
+    }
+  }
+
+  def insert(doc: BSONDocument) = repository.collection.insert(doc)
+}

--- a/it/repositories/parity/ParityExportMongoRepositorySpec.scala
+++ b/it/repositories/parity/ParityExportMongoRepositorySpec.scala
@@ -43,7 +43,7 @@ class ParityExportMongoRepositorySpec extends MongoRepositorySpec with CommonRep
       result.head.applicationId mustBe "app1"
     }
 
-    "return nothing when EXPORTED" in {
+    "return nothing when no applications are in READY_FOR_EXPORT" in {
       val result = parityExportMongoRepo.nextApplicationsForExport(batchSize = 1).futureValue
       result mustBe empty
     }

--- a/it/repositories/parity/ParityExportMongoRepositorySpec.scala
+++ b/it/repositories/parity/ParityExportMongoRepositorySpec.scala
@@ -1,0 +1,86 @@
+package repositories.parity
+
+import config.{ LaunchpadGatewayConfig, Phase3TestsConfig }
+import model.ApplicationStatus.ApplicationStatus
+import model.EvaluationResults.Green
+import model.Exceptions.PassMarkEvaluationNotFound
+import model.SchemeType._
+import model.persisted._
+import model.persisted.phase3tests.Phase3TestGroup
+import model.{ ApplicationStatus, ProgressStatuses, SchemeType }
+import org.scalatest.mock.MockitoSugar
+import play.api.libs.json.JsArray
+import reactivemongo.bson.BSONDocument
+import reactivemongo.json.ImplicitBSONHandlers
+import repositories.CommonRepository
+import repositories.parity.ParityExportRepository.ApplicationIdNotFoundException
+import testkit.MongoRepositorySpec
+
+
+class ParityExportMongoRepositorySpec extends MongoRepositorySpec with CommonRepository with MockitoSugar {
+
+  import ImplicitBSONHandlers._
+  import model.Phase3TestProfileExamples._
+
+  val collectionName: String = "application"
+
+  "next Applications Ready For export" must {
+
+    val resultToSave = List(SchemeEvaluationResult(SchemeType.Commercial, Green.toString))
+
+    "return nothing if application does not have READY_FOR_EXPORT" in {
+      insertApplication("app1", ApplicationStatus.PHASE3_TESTS)
+      val result = parityExportMongoRepo.nextApplicationsForExport(batchSize = 1).futureValue
+      result mustBe empty
+    }
+
+    "return application id in READY_FOR_EXPORT" in {
+      insertApplication("app1", ApplicationStatus.READY_FOR_EXPORT, None)
+
+      val result = parityExportMongoRepo.nextApplicationsForExport(batchSize = 1).futureValue
+
+      result.size mustBe 1
+      result.head.applicationId mustBe "app1"
+    }
+
+    "return nothing when EXPORTED" in {
+      val result = parityExportMongoRepo.nextApplicationsForExport(batchSize = 1).futureValue
+      result mustBe empty
+    }
+
+    "limit number of next applications to the batch size limit" in {
+      val batchSizeLimit = 5
+      1 to 6 foreach { id =>
+        insertApplication(s"app$id", ApplicationStatus.READY_FOR_EXPORT)
+      }
+      val result = parityExportMongoRepo.nextApplicationsForExport(batchSizeLimit).futureValue
+      result.size mustBe batchSizeLimit
+    }
+
+    "return less number of applications than batch size limit" in {
+      val batchSizeLimit = 5
+      1 to 2 foreach { id =>
+        insertApplication(s"app$id", ApplicationStatus.READY_FOR_EXPORT)
+      }
+      val result = parityExportMongoRepo.nextApplicationsForExport(batchSizeLimit).futureValue
+      result.size mustBe 2
+    }
+  }
+
+  "get application for export" must {
+
+    "return a full application as a JsValue when valid" in {
+      insertApplication("app1", ApplicationStatus.READY_FOR_EXPORT)
+
+      val result = parityExportMongoRepo.getApplicationForExport("app1").futureValue
+      (result \ "applicationId").as[String] mustBe "app1"
+      (result \ "userId").as[String] must not be empty
+      (result \ "applicationStatus").as[String] must not be empty
+      (result \ "scheme-preferences" \ "schemes").as[JsArray].value.head.as[String] mustBe Commercial.toString
+    }
+
+    "throw an exception when an applicationId is invalid" in {
+        val result = parityExportMongoRepo.getApplicationForExport("app1").failed.futureValue mustBe a[ApplicationIdNotFoundException]
+    }
+  }
+}

--- a/test/scheduler/parity/ParityExportJobSpec.scala
+++ b/test/scheduler/parity/ParityExportJobSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package scheduler.parity
+
+import config.ScheduledJobConfig
+import model.Exceptions.ConnectorException
+import org.joda.time.{ DateTime, DateTimeZone }
+import org.mockito.ArgumentMatchers.{ eq => eqTo, _ }
+import org.mockito.Mockito._
+import play.api.mvc.RequestHeader
+import repositories.parity.ApplicationReadyForExport
+import services.parity.ParityExportService
+import testkit.UnitWithAppSpec
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ParityExportJobSpec extends UnitWithAppSpec {
+  implicit val now: DateTime = DateTime.now().withZone(DateTimeZone.UTC)
+
+  "Scheduler execution" should {
+    "export applications ready for export" in new TestFixture {
+      val appId = "appId1"
+      when(mockParityService.nextApplicationsForExport(any[Int])).thenReturn(Future.successful(
+          ApplicationReadyForExport(appId) :: Nil
+        ))
+      when(mockParityService.exportApplication(any[String])(any[HeaderCarrier](), any[RequestHeader]())).thenReturn(Future.successful(
+        ()
+      ))
+
+      scheduler.tryExecute().futureValue
+
+      verify(mockParityService, times(1)).nextApplicationsForExport(eqTo(batchSize))
+      verify(mockParityService, times(1)).exportApplication(eqTo(appId))(any[HeaderCarrier](), any[RequestHeader]())
+    }
+
+    "export all applications even when some of them fail" in new TestFixture {
+      val appIds = List("appId1", "appId2", "appId3", "appId4")
+      when(mockParityService.nextApplicationsForExport(any[Int])).thenReturn(Future.successful(
+        appIds.map(ApplicationReadyForExport(_))
+      ))
+
+      when(mockParityService.exportApplication(eqTo(appIds(1)))(any[HeaderCarrier](), any[RequestHeader]())).thenReturn(Future.failed(
+        new ConnectorException("Second application could not send")
+      ))
+
+      when(mockParityService.exportApplication(eqTo(appIds(3)))(any[HeaderCarrier](), any[RequestHeader]())).thenReturn(Future.failed(
+        new ConnectorException("Second application could not send")
+      ))
+
+      when(mockParityService.exportApplication(any[String]())(any[HeaderCarrier](), any[RequestHeader]())).thenReturn(Future.successful(
+        ()
+      ))
+
+      val result = scheduler.tryExecute().futureValue
+
+      verify(mockParityService, times(1)).exportApplication(eqTo(appIds.head))(any[HeaderCarrier](), any[RequestHeader]())
+      verify(mockParityService, times(1)).exportApplication(eqTo(appIds(1)))(any[HeaderCarrier](), any[RequestHeader]())
+      verify(mockParityService, times(1)).exportApplication(eqTo(appIds(2)))(any[HeaderCarrier](), any[RequestHeader]())
+      verify(mockParityService, times(1)).exportApplication(eqTo(appIds(3)))(any[HeaderCarrier](), any[RequestHeader]())
+    }
+
+    "do not export an application if none of them are ready for export" in new TestFixture {
+      when(mockParityService.nextApplicationsForExport(any[Int])).thenReturn(Future.successful(
+        Nil
+      ))
+      scheduler.tryExecute().futureValue
+
+      verify(mockParityService, never).exportApplication(any())(any[HeaderCarrier](), any[RequestHeader]())
+    }
+  }
+
+  trait TestFixture {
+    val batchSize = 1
+    val mockParityService = mock[ParityExportService]
+    val mockParityJobConfig = ScheduledJobConfig(
+      enabled = false,
+      Some("test"),
+      initialDelaySecs = None,
+      intervalSecs = None,
+      batchSize = Some(batchSize)
+    )
+
+    lazy val scheduler = new ParityExportJob {
+      val service = mockParityService
+      val parityExportJobConfig = mockParityJobConfig
+    }
+  }
+}


### PR DESCRIPTION
- Add tests for parity export
- Make sure empty media strings are None during export. 
- Fix bug with 'prefer not to say' in test data generation
- Audit exported applications

TODO: Tests for ParityExportService