### PR TITLE
Add -Ywarn-value-discard scalac option for main compile and fix issues

### DIFF
--- a/app/repositories/application/GeneralApplicationRepository.scala
+++ b/app/repositories/application/GeneralApplicationRepository.scala
@@ -578,7 +578,7 @@ class GeneralApplicationMongoRepository(timeZoneService: TimeZoneService,
       )
     )
 
-    bsonCollection.findAndModify(query, updateOp).map(_.result[Candidate])
+    bsonCollection.findAndModify(query, updateOp).map(_ => ())
   }
 
   def fixDataByRemovingProgressStatus(appId: String, progressStatus: String): Future[Unit] = {
@@ -591,7 +591,7 @@ class GeneralApplicationMongoRepository(timeZoneService: TimeZoneService,
       "$unset" -> BSONDocument(s"progress-status-timestamp.$progressStatus" -> "")
     ))
 
-    bsonCollection.findAndModify(query, updateOp).map(_.result[Candidate])
+    bsonCollection.findAndModify(query, updateOp).map(_ => ())
   }
 
   private def applicationPreferencesWithTestResults(query: BSONDocument): Future[List[ApplicationPreferencesWithTestResults]] = {

--- a/app/scheduler/allocation/ConfirmAttendanceReminderJob.scala
+++ b/app/scheduler/allocation/ConfirmAttendanceReminderJob.scala
@@ -41,7 +41,7 @@ trait ConfirmAttendanceReminderJob extends SingleInstanceScheduledJob with Confi
       case Some(candidate) =>
         candidateAllocationService.sendEmailConfirmationReminder(candidate)
       case None =>
-        Future.successful(Unit)
+        Future.successful(())
     }
   }
 }

--- a/app/scheduler/onlinetesting/SendInvitationJob.scala
+++ b/app/scheduler/onlinetesting/SendInvitationJob.scala
@@ -47,7 +47,7 @@ trait SendInvitationJob extends SingleInstanceScheduledJob {
   def tryExecute()(implicit ec: ExecutionContext): Future[Unit] = {
     onlineTestingService.nextApplicationReadyForOnlineTesting.flatMap {
       case Nil =>
-        Future.successful(Unit)
+        Future.successful(())
       case applications =>
         implicit val hc = new HeaderCarrier()
         implicit val rh = EmptyRequestHeader

--- a/app/services/onlinetesting/OnlineTestFailureService.scala
+++ b/app/services/onlinetesting/OnlineTestFailureService.scala
@@ -48,7 +48,7 @@ class OnlineTestFailureServiceImpl(
 
   override def processNextFailedTest(): Future[Unit] = {
     //TODO FAST STREAM FIX ME
-    Future.successful(Unit)
+    Future.successful(())
     //otRepository.nextApplicationPendingFailure.flatMap {
     //  case Some(failedTest) => processFailedTest(failedTest)
     //  case None => Future.successful(())

--- a/app/services/reporting/AnswerProcessor.scala
+++ b/app/services/reporting/AnswerProcessor.scala
@@ -18,40 +18,7 @@ package services.reporting
 
 import model.PersistedObjects.PersistedAnswer
 
-trait AnswerProcessorTrait {
-  this: Calculable with Collector =>
-
-  def process(answers: List[Map[String, String]]): Unit = {
-    processAnswers(answers)
-  }
-
-  def processAnswers(answers: List[Map[String, String]]): Unit = {
-    for {
-      answer <- answers
-    } yield {
-      val score = calculate(answer)
-      updateTotals(score)
-    }
-  }
-
-  def updateTotals(score: String) = {
-    collectorMap.get(score) match {
-      case Some(_) => collectorMap(score) += 1
-      case _ =>
-    }
-  }
-}
-
 trait Calculable {
   def calculateAsInt(answers: Map[String, PersistedAnswer]): Int
   def calculate(answers: Map[String, String]): String
-}
-
-trait Collector {
-
-  type Message
-
-  def collectorMap: collection.mutable.Map[String, Int]
-
-  def createMessage: Message
 }

--- a/it/repositories/ApplicationRepositorySpec.scala
+++ b/it/repositories/ApplicationRepositorySpec.scala
@@ -79,9 +79,8 @@ class ApplicationRepositorySpec extends MongoRepositorySpec {
 
   "Finding an application by User Id" should {
     "throw a NotFound exception when application doesn't exists" in {
-      applicationRepo.findByUserId("invalidUser", "invalidFramework")
-      an[ApplicationNotFound] must be thrownBy Await.result(applicationRepo
-        .findByUserId("invalidUser", "invalidFramework"), timeout)
+      val result = applicationRepo.findByUserId("invalidUser", "invalidFramework")
+      result.failed.futureValue mustBe an[ApplicationNotFound]
     }
 
     "throw an exception not of the type ApplicationNotFound when application is corrupt" in {

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import de.heikoseeberger.sbtheader.{AutomateHeaderPlugin, HeaderPlugin}
+import de.heikoseeberger.sbtheader.{ AutomateHeaderPlugin, HeaderPlugin }
 import sbt.Keys._
-import sbt.Tests.{Group, SubProcess}
+import sbt.Tests.{ Group, SubProcess }
 import sbt._
 import uk.gov.hmrc.SbtAutoBuildPlugin
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
@@ -53,7 +53,9 @@ trait MicroService {
       parallelExecution in Test := false,
       fork in Test := false,
       retrieveManaged := true,
-      scalacOptions += "-feature")
+      scalacOptions += "-feature",
+      // Currently don't enable warning in value discard in tests until ScalaTest 3
+      scalacOptions in (Compile, compile) += "-Ywarn-value-discard")
     .settings(sources in (Compile, doc) := Seq.empty)
     .settings(HeaderPlugin.settingsFor(IntegrationTest))
     .configs(IntegrationTest)
@@ -73,9 +75,9 @@ trait MicroService {
 //      (compile in Compile) <<= (compile in Compile) dependsOn compileScalastyle)
     .settings(
       Keys.fork in IntegrationTest := false,
-      unmanagedSourceDirectories in IntegrationTest <<= (baseDirectory in IntegrationTest)(base => Seq(
+      unmanagedSourceDirectories in IntegrationTest := (baseDirectory in IntegrationTest)(base => Seq(
         base / "it", base / "test/model", base / "test/testkit"
-      )),
+      )).value,
       addTestReportOption(IntegrationTest, "int-test-reports"),
       testGrouping in IntegrationTest := oneForkedJvmPerTest((definedTests in IntegrationTest).value),
       parallelExecution in IntegrationTest := false)


### PR DESCRIPTION
Adding the warn-value-discard should help with issues where futures are orphaned accidentally with map instead of flatMap, and other similar circumstance