### PR TITLE
FSET-1008 Move test expiry to test score evaluation

### DIFF
--- a/app/repositories/onlinetesting/OnlineTestRepository.scala
+++ b/app/repositories/onlinetesting/OnlineTestRepository.scala
@@ -97,12 +97,11 @@ trait OnlineTestRepository extends RandomSelection with ReactiveRepositoryHelper
 
   def updateTestCompletionTime(cubiksUserId: Int, completedTime: DateTime) = {
     import repositories.BSONDateTimeHandler
-    val query = BSONDocument(s"testGroups.$phaseName.expirationDate" -> BSONDocument("$gt" -> DateTime.now(DateTimeZone.UTC)))
     val update = BSONDocument("$set" -> BSONDocument(
       s"testGroups.$phaseName.tests.$$.completedDateTime" -> Some(completedTime)
     ))
 
-    findAndUpdateCubiksTest(cubiksUserId, update, query, ignoreNotFound = true)
+    findAndUpdateCubiksTest(cubiksUserId, update, ignoreNotFound = true)
   }
 
   def updateTestReportReady(cubiksUserId: Int, reportReady: CubiksTestResultReady) = {
@@ -197,9 +196,8 @@ trait OnlineTestRepository extends RandomSelection with ReactiveRepositoryHelper
     selectOneRandom[TestGroup](query)
   }
 
-  private def findAndUpdateCubiksTest(cubiksUserId: Int, update: BSONDocument, query: BSONDocument = BSONDocument.empty,
-                                      ignoreNotFound: Boolean = false): Future[Unit] = {
-        val find = query ++ BSONDocument(
+  private def findAndUpdateCubiksTest(cubiksUserId: Int, update: BSONDocument, ignoreNotFound: Boolean = false): Future[Unit] = {
+        val find = BSONDocument(
       s"testGroups.$phaseName.tests" -> BSONDocument(
         "$elemMatch" -> BSONDocument("cubiksUserId" -> cubiksUserId)
       )

--- a/it/repositories/CommonRepository.scala
+++ b/it/repositories/CommonRepository.scala
@@ -6,6 +6,7 @@ import model.ApplicationStatus.ApplicationStatus
 import model.Phase1TestExamples._
 import model.Phase2TestProfileExamples._
 import model.Phase3TestProfileExamples._
+import model.ProgressStatuses.ProgressStatus
 import model.SchemeType._
 import model.persisted._
 import model.persisted.phase3tests.{ LaunchpadTest, Phase3TestGroup }
@@ -103,12 +104,14 @@ trait CommonRepository {
                         phase2Tests: Option[List[CubiksTest]] = None, phase3Tests: Option[List[LaunchpadTest]] = None,
                         isGis: Boolean = false, schemes: List[SchemeType] = List(Commercial),
                         phase1Evaluation: Option[PassmarkEvaluation] = None,
-                        phase2Evaluation: Option[PassmarkEvaluation] = None): Unit = {
+                        phase2Evaluation: Option[PassmarkEvaluation] = None,
+                        additionalProgressStatuses: List[(ProgressStatus, Boolean)] = List.empty): Unit = {
     val gis = if (isGis) Some(true) else None
     applicationRepository.collection.insert(BSONDocument(
       "applicationId" -> appId,
       "userId" -> appId,
-      "applicationStatus" -> applicationStatus
+      "applicationStatus" -> applicationStatus,
+      "progress-status" -> progressStatus(additionalProgressStatuses)
     )).futureValue
 
     val ad = AssistanceDetails("No", None, gis, needsSupportForOnlineAssessment = Some(false), None,
@@ -148,4 +151,27 @@ trait CommonRepository {
     }
   }
 
+  private def questionnaire() = {
+    BSONDocument(
+      "start_questionnaire" -> true,
+      "diversity_questionnaire" -> true,
+      "education_questionnaire" -> true,
+      "occupation_questionnaire" -> true
+    )
+  }
+  
+  def progressStatus(args: List[(ProgressStatus, Boolean)] = List.empty): BSONDocument = {
+    val baseDoc = BSONDocument(
+      "personal-details" -> true,
+      "in_progress" -> true,
+      "scheme-preferences" -> true,
+      "partner-graduate-programmes" -> true,
+      "assistance-details" -> true,
+      "questionnaire" -> questionnaire(),
+      "preview" -> true,
+      "submitted" -> true
+    )
+
+    args.foldLeft(baseDoc)((acc, v) => acc.++(v._1.toString -> v._2))
+  }
 }

--- a/it/repositories/Phase3TestEvaluationSpec.scala
+++ b/it/repositories/Phase3TestEvaluationSpec.scala
@@ -10,30 +10,18 @@ import model.persisted.{ ApplicationReadyForEvaluation, PassmarkEvaluation, Sche
 import org.joda.time.DateTime
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.prop._
-import play.api.test.Helpers
-import reactivemongo.bson.BSONDocument
 import reactivemongo.json.ImplicitBSONHandlers
-import reactivemongo.json.collection.JSONCollection
 import services.onlinetesting.EvaluatePhase3ResultService
 import testkit.MongoRepositorySpec
 
-import scala.concurrent.Await
 
-
-class Phase3TestEvaluationSpec extends MongoRepositorySpec with CommonRepository with MockitoSugar
+class Phase3TestEvaluationSpec extends MongoRepositorySpec with CommonRepository
   with TableDrivenPropertyChecks {
 
   import ImplicitBSONHandlers._
 
   val collectionName = "application"
-
-  override def withFixture(test: NoArgTest) = {
-    Helpers.running(app) {
-      val collection = mongo().collection[JSONCollection]("phase3-pass-mark-settings")
-      Await.ready(collection.remove(BSONDocument.empty), timeout)
-      super.withFixture(test)
-    }
-  }
+  override val additionalCollections = List("phase3-pass-mark-settings")
 
   def phase3TestEvaluationService = new EvaluatePhase3ResultService {
     val evaluationRepository = phase3EvaluationRepo

--- a/it/repositories/onlinetesting/Phase1EvaluationMongoRepositorySpec.scala
+++ b/it/repositories/onlinetesting/Phase1EvaluationMongoRepositorySpec.scala
@@ -64,6 +64,15 @@ class Phase1EvaluationMongoRepositorySpec extends MongoRepositorySpec with Commo
         selectedSchemes(List(Commercial)))
     }
 
+    "return nothing when PHASE1_TESTS have expired" in {
+      insertApplication("app1", ApplicationStatus.PHASE1_TESTS, Some(phase1TestsWithResult),
+        additionalProgressStatuses = List(ProgressStatuses.PHASE1_TESTS_EXPIRED -> true))
+
+      val result = phase1EvaluationRepo.nextApplicationsReadyForEvaluation("version1", batchSize = 1).futureValue
+
+      result mustBe empty
+    }
+
     "limit number of next applications to the batch size limit" in {
       val batchSizeLimit = 5
       1 to 6 foreach { id =>

--- a/it/repositories/onlinetesting/Phase1TestRepositorySpec.scala
+++ b/it/repositories/onlinetesting/Phase1TestRepositorySpec.scala
@@ -485,29 +485,6 @@ class Phase1TestRepositorySpec extends MongoRepositorySpec with ApplicationDataF
         result.testGroup.tests.head.completedDateTime mustBe Some(now)
       }
 
-      "not complete tests if the profile has expired" in {
-        val now = DateTime.now(DateTimeZone.UTC)
-        val input = Phase1TestProfile(expirationDate = now,
-          tests = List(CubiksTest(scheduleId = 1,
-            usedForResults = true,
-            token = "token",
-            cubiksUserId = 111,
-            testUrl = "testUrl",
-            invitationDate = now,
-            participantScheduleId = 222
-          ))
-        )
-
-        createApplicationWithAllFields("userId", "appId", "frameworkId", "PHASE1_TESTS", needsSupportForOnlineAssessment = false,
-          adjustmentsConfirmed = false, timeExtensionAdjustments = false, fastPassApplicable = false,
-          fastPassReceived = false, phase1TestProfile = Some(input)
-        ).futureValue
-
-        phase1TestRepo.updateTestCompletionTime(111, now).futureValue
-        val result = phase1TestRepo.getTestProfileByCubiksId(111).futureValue
-        result.testGroup.tests.head.completedDateTime mustBe None
-      }
-
       "mark the cubiks test as inactive" in {
         insertApplication("appId", "userId")
         phase1TestRepo.insertOrUpdateTestGroup("appId", TestProfile).futureValue

--- a/it/repositories/onlinetesting/Phase2EvaluationMongoRepositorySpec.scala
+++ b/it/repositories/onlinetesting/Phase2EvaluationMongoRepositorySpec.scala
@@ -2,6 +2,7 @@ package repositories.onlinetesting
 
 import model.ApplicationStatus.ApplicationStatus
 import model.EvaluationResults.Green
+import model.Phase3TestProfileExamples._
 import model.SchemeType._
 import model.persisted.{ ApplicationReadyForEvaluation, _ }
 import model.{ ApplicationStatus, ProgressStatuses, SchemeType }
@@ -57,6 +58,17 @@ class Phase2EvaluationMongoRepositorySpec extends MongoRepositorySpec with Commo
       phase2EvaluationRepo.savePassmarkEvaluation("app1", phase2Evaluation, None).futureValue
 
       val result = phase2EvaluationRepo.nextApplicationsReadyForEvaluation("phase2_version1", batchSize = 1).futureValue
+      result mustBe empty
+    }
+
+    "return nothing when PHASE2_TESTS have expired" in {
+      val phase1Evaluation = PassmarkEvaluation("phase1_version1", None, resultToSave)
+      insertApplication("app1", ApplicationStatus.PHASE2_TESTS, Some(phase1TestsWithResult),
+        Some(phase2TestWithResult), phase1Evaluation = Some(phase1Evaluation),
+        additionalProgressStatuses = List(ProgressStatuses.PHASE2_TESTS_EXPIRED -> true))
+
+      val result = phase2EvaluationRepo.nextApplicationsReadyForEvaluation("phase1_version1", batchSize = 1).futureValue
+
       result mustBe empty
     }
 

--- a/it/repositories/onlinetesting/Phase2TestRepositorySpec.scala
+++ b/it/repositories/onlinetesting/Phase2TestRepositorySpec.scala
@@ -272,29 +272,6 @@ class Phase2TestRepositorySpec extends MongoRepositorySpec with ApplicationDataF
       val result = phase2TestRepo.getTestProfileByCubiksId(111).futureValue
       result.testGroup.tests.head.completedDateTime mustBe Some(now)
     }
-
-    "not update profiles that have expired" in {
-      val now =  DateTime.now(DateTimeZone.UTC)
-      val input = Phase2TestGroup(expirationDate = now,
-        tests = List(CubiksTest(scheduleId = 1,
-          usedForResults = true,
-          token = "token",
-          cubiksUserId = 111,
-          testUrl = "testUrl",
-          invitationDate = now,
-          participantScheduleId = 222
-        ))
-      )
-
-      createApplicationWithAllFields("userId", "appId", "frameworkId", "PHASE2_TESTS", needsSupportForOnlineAssessment = false,
-        needsSupportAtVenue = false, adjustmentsConfirmed = false, timeExtensionAdjustments = false, fastPassApplicable = false,
-        fastPassReceived = false, phase2TestGroup = Some(input)
-      ).futureValue
-
-      phase2TestRepo.updateTestCompletionTime(111, now).futureValue
-      val result = phase2TestRepo.getTestProfileByCubiksId(111).futureValue
-      result.testGroup.tests.head.completedDateTime mustBe None
-    }
   }
 
   "Insert test result" should {


### PR DESCRIPTION
The previous scheme of not recording callbacks for tests which have expired caused issues when the tests were extended. The following changes have been made in this PR
-  I have moved the code to the query that selects candidates for the rules evaluation. This means that the test scores will be successfully downloaded for Cubiks tests, ensuring the Cubiks test was successfully completed and recorded. It should make it easier to answer support queries for candidates who believe they did the test before expiry. 
- The phase3/video rules evaluator didn't take into account expiry either, but now should
- The tests were fairly slow as they are doing the setup in series. I have improved the low hanging fruit
