### PR TITLE
FSET 1533: Allow bq and sjq setting in phase1testdata

### DIFF
--- a/app/connectors/testdata/ExchangeObjects.scala
+++ b/app/connectors/testdata/ExchangeObjects.scala
@@ -46,7 +46,7 @@ object ExchangeObjects {
 
   case class TestGroupResponse(tests: List[TestResponse])
 
-  case class TestResponse(testId: Int, token: String, testUrl: String)
+  case class TestResponse(testId: Int, testType: String, token: String, testUrl: String)
 
 
   object Implicits {

--- a/app/controllers/testdata/TestDataGeneratorController.scala
+++ b/app/controllers/testdata/TestDataGeneratorController.scala
@@ -101,7 +101,10 @@ trait TestDataGeneratorController extends BaseController {
       phase3TestData = Some(Phase3TestDataRequest(
         start = Some("2340-01-01"),
         expiry = Some("2340-01-29"),
-        completion = Some("2340-01-16")
+        completion = Some("2340-01-16"),
+        score = Some(12.0),
+        receivedBeforeInHours = Some(72),
+        generateNullScoresForFewQuestions = Some(false)
       )),
       adjustmentInformation = Some(Adjustments(
         adjustments = Some(List("etrayInvigilated", "videoInvigilated")),

--- a/app/controllers/testdata/TestDataGeneratorController.scala
+++ b/app/controllers/testdata/TestDataGeneratorController.scala
@@ -89,7 +89,8 @@ trait TestDataGeneratorController extends BaseController {
         start = Some("2340-01-01"),
         expiry = Some("2340-01-29"),
         completion = Some("2340-01-16"),
-        tscore = Some("80")
+        bqtscore = Some("80"),
+        sjqtscore = Some("70")
       )),
       phase2TestData = Some(Phase2TestDataRequest(
         start = Some("2340-01-01"),

--- a/app/model/ReminderNotice.scala
+++ b/app/model/ReminderNotice.scala
@@ -17,6 +17,7 @@
 package model
 
 import model.ProgressStatuses._
+import model.ReminderNotice.UnrecognisedReminderNoticeProgressStatusException
 
 import scala.concurrent.duration.{ DAYS, HOURS, TimeUnit }
 
@@ -33,6 +34,8 @@ sealed case class ReminderNotice(hoursBeforeReminder: Int, progressStatuses: Pro
     case PHASE2_TESTS_FIRST_REMINDER => (DAYS, Phase_2)
     case PHASE3_TESTS_SECOND_REMINDER => (HOURS, Phase_3)
     case PHASE3_TESTS_FIRST_REMINDER => (DAYS, Phase_3)
+    case status => throw UnrecognisedReminderNoticeProgressStatusException(s"$status is an unrecognised progress status " +
+      s"for reminder notices")
   }
 
   val timeUnit: TimeUnit = timeUnitAndPhase._1
@@ -45,3 +48,7 @@ object Phase2FirstReminder extends ReminderNotice(72, PHASE2_TESTS_FIRST_REMINDE
 object Phase2SecondReminder extends ReminderNotice(24, PHASE2_TESTS_SECOND_REMINDER)
 object Phase3FirstReminder extends ReminderNotice(72, PHASE3_TESTS_FIRST_REMINDER)
 object Phase3SecondReminder extends ReminderNotice(24, PHASE3_TESTS_SECOND_REMINDER)
+
+object ReminderNotice {
+  case class UnrecognisedReminderNoticeProgressStatusException(msg: String) extends Exception(msg)
+}

--- a/app/model/ReminderNotice.scala
+++ b/app/model/ReminderNotice.scala
@@ -38,8 +38,7 @@ sealed case class ReminderNotice(hoursBeforeReminder: Int, progressStatuses: Pro
       s"for reminder notices")
   }
 
-  val timeUnit: TimeUnit = timeUnitAndPhase._1
-  val phase: String = timeUnitAndPhase._2
+  val (timeUnit, phase) = timeUnitAndPhase
 }
 
 object Phase1FirstReminder extends ReminderNotice(72, PHASE1_TESTS_FIRST_REMINDER)

--- a/app/model/command/testdata/GeneratorConfig.scala
+++ b/app/model/command/testdata/GeneratorConfig.scala
@@ -78,18 +78,20 @@ case class Phase1TestData(
   start: Option[DateTime] = None,
   expiry: Option[DateTime] = None,
   completion: Option[DateTime] = None,
-  tscore: Option[Double] = None,
+  bqtscore: Option[Double] = None,
+  sjqtscore: Option[Double] = None,
   passmarkEvaluation: Option[PassmarkEvaluation] = None
-) extends TestDates with TestResult
+) extends TestDates
 
 object Phase1TestData {
-  def apply(o: model.exchange.testdata.Phase1TestDataRequest): Phase1TestData = {
+  def apply(testDataRequest: model.exchange.testdata.Phase1TestDataRequest): Phase1TestData = {
     Phase1TestData(
-      start = o.start.map(DateTime.parse),
-      expiry = o.expiry.map(DateTime.parse),
-      completion = o.completion.map(DateTime.parse),
-      tscore = o.tscore.map(_.toDouble),
-      passmarkEvaluation = o.passmarkEvaluation
+      start = testDataRequest.start.map(DateTime.parse),
+      expiry = testDataRequest.expiry.map(DateTime.parse),
+      completion = testDataRequest.completion.map(DateTime.parse),
+      bqtscore = testDataRequest.bqtscore.map(_.toDouble),
+      sjqtscore = testDataRequest.sjqtscore.map(_.toDouble),
+      passmarkEvaluation = testDataRequest.passmarkEvaluation
     )
   }
 }

--- a/app/model/exchange/testdata/CreateCandidateInStatusRequest.scala
+++ b/app/model/exchange/testdata/CreateCandidateInStatusRequest.scala
@@ -51,9 +51,10 @@ case class Phase1TestDataRequest(
   start: Option[String] = None,
   expiry: Option[String] = None,
   completion: Option[String] = None,
-  tscore: Option[String] = None,
+  bqtscore: Option[String] = None,
+  sjqtscore: Option[String] = None,
   passmarkEvaluation: Option[PassmarkEvaluation] = None
-) extends TestDatesRequest with TestResultRequest
+) extends TestDatesRequest
 
 object Phase1TestDataRequest {
   implicit val phase1TestDataFormat = Json.format[Phase1TestDataRequest]

--- a/app/services/onlinetesting/phase3/Phase3TestService.scala
+++ b/app/services/onlinetesting/phase3/Phase3TestService.scala
@@ -286,31 +286,7 @@ trait Phase3TestService extends OnlineTestService with Phase3TestConcern {
       )
     )
   }
-
   //scalastyle:on method.length
-  @deprecated
-  private def registerAndInviteApplicant(application: OnlineTestApplication, emailAddress: String, interviewId: Int, invitationDate: DateTime,
-                                         expirationDate: DateTime
-                                        )(implicit hc: HeaderCarrier, rh: RequestHeader): Future[LaunchpadTest] = {
-    val customCandidateId = "FSCND-" + tokenFactory.generateUUID()
-
-    for {
-      candidateId <- registerApplicant(application, emailAddress, customCandidateId)
-      invitation <- inviteApplicant(application, interviewId, candidateId)
-    } yield {
-      LaunchpadTest(interviewId = interviewId,
-        usedForResults = true,
-        testUrl = invitation.testUrl,
-        token = invitation.customInviteId,
-        candidateId = candidateId,
-        customCandidateId = invitation.customCandidateId,
-        invitationDate = invitationDate,
-        startedDateTime = None,
-        completedDateTime = None,
-        callbacks = LaunchpadTestCallbacks()
-      )
-    }
-  }
 
   def markAsStarted(launchpadInviteId: String, startedTime: DateTime = dateTimeFactory.nowLocalTimeZone)
                    (implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = eventSink {

--- a/app/services/testdata/onlinetests/phase1/Phase1TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/onlinetests/phase1/Phase1TestsInvitedStatusGenerator.scala
@@ -78,9 +78,9 @@ trait Phase1TestsInvitedStatusGenerator extends ConstructiveGenerator {
 
       candidateInPreviousStatus.copy(phase1TestGroup = Some(
         TestGroupResponse(
-          List(TestResponse(sjq.cubiksUserId, sjq.token, sjq.testUrl)) ++
+          List(TestResponse(sjq.cubiksUserId, "sjq", sjq.token, sjq.testUrl)) ++
           bq.map { b =>
-            List(TestResponse(b.cubiksUserId, b.token, b.testUrl))
+            List(TestResponse(b.cubiksUserId, "bq", b.token, b.testUrl))
           }.getOrElse(Nil)
         )
       ))

--- a/app/services/testdata/onlinetests/phase2/Phase2TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/onlinetests/phase2/Phase2TestsInvitedStatusGenerator.scala
@@ -76,7 +76,7 @@ trait Phase2TestsInvitedStatusGenerator extends ConstructiveGenerator {
       val etray = phase2TestGroup.tests.head
 
       candidateInPreviousStatus.copy(
-        phase2TestGroup = Some(TestGroupResponse(List(TestResponse(etray.cubiksUserId, etray.token, etray.testUrl)))),
+        phase2TestGroup = Some(TestGroupResponse(List(TestResponse(etray.cubiksUserId, "etray", etray.token, etray.testUrl)))),
         accessCode = etray.invigilatedAccessCode
       )
     }

--- a/app/services/testdata/onlinetests/phase3/Phase3TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/onlinetests/phase3/Phase3TestsInvitedStatusGenerator.scala
@@ -70,7 +70,7 @@ trait Phase3TestsInvitedStatusGenerator extends ConstructiveGenerator {
       expirationDate = generatorConfig.phase3TestData.flatMap(_.expiry).getOrElse(DateTime.now().plusDays(7)),
       tests = List(launchpad)
     )
-    
+
     for {
       candidateInPreviousStatus <- previousStatusGenerator.generate(generationId, generatorConfig)
       phase3TestApplication = OnlineTestApplication(
@@ -88,7 +88,7 @@ trait Phase3TestsInvitedStatusGenerator extends ConstructiveGenerator {
       _ <- p3Repository.insertOrUpdateTestGroup(candidateInPreviousStatus.applicationId.get, phase3TestGroup)
       testGroup <- p3Repository.getTestGroup(phase3TestApplication.applicationId)
     } yield {
-      val phase3TestGroupResponse = TestResponse(testId = launchpad.interviewId, token = launchpad.token,
+      val phase3TestGroupResponse = TestResponse(testId = launchpad.interviewId, testType = "video", token = launchpad.token,
         testUrl = testGroup.get.tests.find(_.usedForResults).get.testUrl)
 
       candidateInPreviousStatus.copy(


### PR DESCRIPTION
Belongs with: https://github.tools.tax.service.gov.uk/HMRC/fset-faststream-admin-frontend/pull/158