### PR TITLE
Low-risk refactors to cut down on warnings

### DIFF
--- a/app/config/microserviceGlobal.scala
+++ b/app/config/microserviceGlobal.scala
@@ -16,6 +16,7 @@
 
 package config
 
+import com.github.ghik.silencer.silent
 import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 import play.api.{ Application, Configuration, Play }
@@ -27,7 +28,7 @@ import uk.gov.hmrc.play.http.logging.filters.LoggingFilter
 import uk.gov.hmrc.play.microservice.bootstrap.DefaultMicroserviceGlobal
 
 object ControllerConfiguration extends ControllerConfig with MicroserviceFilterSupport {
-  lazy val controllerConfigs: Config = Play.current.configuration.underlying.as[Config]("controllers")
+  @silent lazy val controllerConfigs: Config = Play.current.configuration.underlying.as[Config]("controllers")
 }
 
 object MicroserviceAuditFilter extends AuditFilter with AppName with MicroserviceFilterSupport {

--- a/app/connectors/CubiksGatewayClient.scala
+++ b/app/connectors/CubiksGatewayClient.scala
@@ -16,8 +16,10 @@
 
 package connectors
 
+import akka.util.ByteString
 import config.MicroserviceAppConfig._
-import config.WSHttp
+import _root_.config.WSHttp
+import akka.stream.scaladsl.Source
 import connectors.ExchangeObjects.{ Invitation, InviteApplicant, RegisterApplicant, Registration }
 import model.Exceptions.ConnectorException
 import model.OnlineTestCommands.Implicits._
@@ -95,21 +97,9 @@ trait CubiksGatewayClient {
       }
     }
   }
-
-  def downloadPdfReport(reportId: Int): Future[Array[Byte]] = {
-    http.playWS.url(s"$url/csr-cubiks-gateway/report-pdf/$reportId").get(respHeaders =>
-      if (respHeaders.status == OK) {
-        Iteratee.consume[Array[Byte]]()
-      } else {
-        throw new ConnectorException(
-          s"There was a general problem connecting to the Cubiks Gateway to download the PDF report '$reportId'. " +
-            s"HTTP response headers were $respHeaders"
-        )
-      }).flatMap { iteratee => iteratee.run }
-  }
 }
 
 object CubiksGatewayClient extends CubiksGatewayClient {
   val http: WSHttp = WSHttp
-  val url = cubiksGatewayConfig.url
+  val url: String = cubiksGatewayConfig.url
 }

--- a/app/model/Commands.scala
+++ b/app/model/Commands.scala
@@ -25,7 +25,6 @@ import model.OnlineTestCommands.Implicits._
 import model.OnlineTestCommands.TestResult
 import model.PassmarkPersistedObjects.{ AssessmentCentrePassMarkInfo, AssessmentCentrePassMarkScheme }
 import model.PassmarkPersistedObjects.Implicits._
-import model.PersistedObjects.{ PersistedAnswer, PersistedQuestion }
 import model.SchemeType.SchemeType
 import org.joda.time.{ DateTime, LocalDate, LocalTime }
 import play.api.libs.json._
@@ -33,6 +32,7 @@ import play.api.libs.json._
 import scala.language.implicitConversions
 import model.command.{ AssessmentCentre, ProgressResponse }
 import model.exchange.passmarksettings.Phase1PassMarkSettings
+import model.persisted.{ QuestionnaireAnswer, QuestionnaireQuestion }
 import model.report.{ CandidateProgressReportItem, QuestionnaireReportItem }
 
 //scalastyle:off
@@ -235,8 +235,8 @@ object Commands {
     implicit val reportFormat = Json.format[Report]
     implicit val preferencesWithContactDetailsFormat = Json.format[PreferencesWithContactDetails]
 
-    implicit def fromCommandToPersistedQuestion(q: Question): PersistedQuestion =
-      PersistedQuestion(q.question, PersistedAnswer(q.answer.answer, q.answer.otherDetails, q.answer.unknown))
+    implicit def fromCommandToPersistedQuestion(q: Question): QuestionnaireQuestion =
+      QuestionnaireQuestion(q.question, QuestionnaireAnswer(q.answer.answer, q.answer.otherDetails, q.answer.unknown))
 
     implicit val onlineTestDetailsFormat = Json.format[OnlineTestDetails]
     implicit val onlineTestFormat = Json.format[OnlineTest]

--- a/app/model/PersistedObjects.scala
+++ b/app/model/PersistedObjects.scala
@@ -16,9 +16,9 @@
 
 package model
 
-import model.Commands.{ PhoneNumber, PostCode }
+import model.Commands.PhoneNumber
 import model.OnlineTestCommands.TestResult
-import org.joda.time.{ DateTime, LocalDate }
+import org.joda.time.LocalDate
 import model.ApplicationStatus._
 import play.api.libs.json._
 import reactivemongo.bson.Macros
@@ -29,9 +29,6 @@ object PersistedObjects {
   case class PersonalDetailsWithUserId(preferredName: String, userId: String)
 
   case class ApplicationIdWithUserIdAndStatus(applicationId: String, userId: String, applicationStatus: String)
-
-  case class PersistedAnswer(answer: Option[String], otherDetails: Option[String], unknown: Option[Boolean])
-  case class PersistedQuestion(question: String, answer: PersistedAnswer)
 
   case class UserIdAndPhoneNumber(userId: String, phoneNumber: Option[PhoneNumber])
 
@@ -70,8 +67,6 @@ object PersistedObjects {
 
   object Implicits {
     implicit val addressFormats = Json.format[Address]
-    implicit val answerFormats = Json.format[PersistedAnswer]
-    implicit val questionFormats = Json.format[PersistedQuestion]
     implicit val personalDetailsWithUserIdFormats = Json.format[PersonalDetailsWithUserId]
     implicit val testFormats = Json.format[TestResult]
     implicit val candidateTestReportFormats = Json.format[CandidateTestReport]

--- a/app/model/persisted/QuestionnaireAnswer.scala
+++ b/app/model/persisted/QuestionnaireAnswer.scala
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package services.reporting
+package model.persisted
 
-import model.persisted.QuestionnaireAnswer
+import play.api.libs.json.Json
 
-trait Calculable {
-  def calculateAsInt(answers: Map[String, QuestionnaireAnswer]): Int
-  def calculate(answers: Map[String, String]): String
+case class QuestionnaireAnswer(answer: Option[String], otherDetails: Option[String], unknown: Option[Boolean])
+object QuestionnaireAnswer
+{
+  implicit val answerFormats = Json.format[QuestionnaireAnswer]
 }

--- a/app/model/persisted/QuestionnaireQuestion.scala
+++ b/app/model/persisted/QuestionnaireQuestion.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package services.reporting
+package model.persisted
 
-import model.persisted.QuestionnaireAnswer
+import play.api.libs.json.Json
 
-trait Calculable {
-  def calculateAsInt(answers: Map[String, QuestionnaireAnswer]): Int
-  def calculate(answers: Map[String, String]): String
+case class QuestionnaireQuestion(question: String, answer: QuestionnaireAnswer)
+object QuestionnaireQuestion {
+  implicit val questionFormats = Json.format[QuestionnaireQuestion]
 }

--- a/app/repositories/AssessmentCentreRepository.scala
+++ b/app/repositories/AssessmentCentreRepository.scala
@@ -18,6 +18,7 @@ package repositories
 
 import java.util
 
+import com.github.ghik.silencer.silent
 import model.Exceptions.{ NoSuchVenueDateException, NoSuchVenueException }
 import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
@@ -60,12 +61,12 @@ trait AssessmentCentreRepositoryImpl extends AssessmentCentreRepository {
   val assessmentCentresConfigPath: String
 
   private lazy val locationsAndAssessmentCentreMappingCached = Future.successful {
-    val input = managed(Play.application.resourceAsStream(assessmentCentresLocationsPath).get)
+    @silent val input = managed(Play.application.resourceAsStream(assessmentCentresLocationsPath).get)
     input.acquireAndGet(file => asMapOfObjects(new Yaml().load(file)))
   }
 
   private lazy val assessmentCentreCapacitiesCached = Future.successful {
-    val input = managed(Play.application.resourceAsStream(assessmentCentresConfigPath).get)
+    @silent val input = managed(Play.application.resourceAsStream(assessmentCentresConfigPath).get)
     input.acquireAndGet(file => asAssessmentCentreCapacity(new Yaml().load(file)))
   }
 

--- a/app/repositories/NorthSouthIndicatorCSVRepository.scala
+++ b/app/repositories/NorthSouthIndicatorCSVRepository.scala
@@ -16,6 +16,7 @@
 
 package repositories
 
+import com.github.ghik.silencer.silent
 import model.report.CandidateProgressReportItem
 import model.{ ApplicationRoute, FSACIndicator }
 import play.api.Play
@@ -31,7 +32,7 @@ object NorthSouthIndicatorCSVRepository extends NorthSouthIndicatorCSVRepository
 
   override private[repositories] val fsacIndicators: Map[String, FSACIndicator] =  {
 
-    val input = managed(Play.application.resourceAsStream(CsvFileName).get)
+    @silent val input = managed(Play.application.resourceAsStream(CsvFileName).get)
     input.acquireAndGet { inputStream =>
       val rawData = Source.fromInputStream(inputStream).getLines.map(parseLine).toList
       val headers = rawData.head

--- a/app/repositories/ReactiveRepositoryHelpers.scala
+++ b/app/repositories/ReactiveRepositoryHelpers.scala
@@ -62,7 +62,7 @@ trait ReactiveRepositoryHelpers {
     }
   }
 
-  private[this] def singleUpdateValidatorImpl(id: String, actionDesc: String, ignoreNotFound: Boolean = false,
+  private[this] def singleUpdateValidatorImpl(id: String, actionDesc: String, ignoreNotFound: Boolean,
                                               notFound: => Exception, upsert: Boolean)(result: UpdateWriteResult) = {
     if (result.ok) {
       if (result.n == 1) {

--- a/app/repositories/application/TestDataRepository.scala
+++ b/app/repositories/application/TestDataRepository.scala
@@ -199,7 +199,7 @@ class TestDataMongoRepository(implicit mongo: () => DB)
     )) //.futureValue
   }
 
-  private def createSingleApplication(id: Int, onlyAwaitingAllocation: Boolean = false,
+  private def createSingleApplication(id: Int, onlyAwaitingAllocation: Boolean,
                                       locationsAndRegions: Seq[(String, String)]): Future[Unit] = {
     val document = buildSingleApplication(id, onlyAwaitingAllocation, locationsAndRegions)
 
@@ -226,7 +226,7 @@ class TestDataMongoRepository(implicit mongo: () => DB)
     progress
   }
 
-  private def buildSingleApplication(id: Int, onlyAwaitingAllocation: Boolean = false, locationsAndRegions: Seq[(String, String)]) = {
+  private def buildSingleApplication(id: Int, onlyAwaitingAllocation: Boolean, locationsAndRegions: Seq[(String, String)]) = {
     val personalDetails = createPersonalDetails(id, onlyAwaitingAllocation)
     val frameworks = createLocations(id, onlyAwaitingAllocation, locationsAndRegions)
     val assistance = createAssistance(id, onlyAwaitingAllocation)
@@ -256,7 +256,7 @@ class TestDataMongoRepository(implicit mongo: () => DB)
     f.map(d => document ++ d).getOrElse(document)
   }
 
-  private def createAssistance(id: Int, buildAlways: Boolean = false) = id match {
+  private def createAssistance(id: Int, buildAlways: Boolean) = id match {
     case x if x % 7 == 0 && !buildAlways => None
     case _ =>
       Some(BSONDocument(
@@ -270,7 +270,7 @@ class TestDataMongoRepository(implicit mongo: () => DB)
       ))
   }
 
-  private def createPersonalDetails(id: Int, buildAlways: Boolean = false) = id match {
+  private def createPersonalDetails(id: Int, buildAlways: Boolean) = id match {
     case x if x % 5 == 0 && !buildAlways => None
     case _ =>
       Some(BSONDocument(
@@ -283,7 +283,7 @@ class TestDataMongoRepository(implicit mongo: () => DB)
       ))
   }
 
-  private def createLocations(id: Int, buildAlways: Boolean = false, regionsAndLocations: Seq[(String, String)] ) = id match {
+  private def createLocations(id: Int, buildAlways: Boolean, regionsAndLocations: Seq[(String, String)] ) = id match {
     case x if x % 11 == 0 && !buildAlways => None
     case _ =>
       val firstLocationRegion = chooseOne(regionsAndLocations)
@@ -315,7 +315,7 @@ class TestDataMongoRepository(implicit mongo: () => DB)
       }
   }
 
-  private def createOnlineTests(id: Int, buildAlways: Boolean = false) = id match {
+  private def createOnlineTests(id: Int, buildAlways: Boolean) = id match {
     case x if x % 12 == 0 && !buildAlways => None
     case _ =>
       Some(BSONDocument(

--- a/app/repositories/onlinetesting/OnlineTestRepository.scala
+++ b/app/repositories/onlinetesting/OnlineTestRepository.scala
@@ -123,7 +123,7 @@ trait OnlineTestRepository extends RandomSelection with ReactiveRepositoryHelper
     throw CannotFindTestByCubiksId(s"Cannot find test group by token: $token")
   }
 
-  private def phaseTestProfileByQuery(query: BSONDocument, phase: String = "PHASE1"): Future[Option[T]] = {
+  private def phaseTestProfileByQuery(query: BSONDocument, phase: String): Future[Option[T]] = {
     val projection = BSONDocument(s"testGroups.$phase" -> 1, "_id" -> 0)
 
     collection.find(query, projection).one[BSONDocument] map { optDocument =>

--- a/app/repositories/package.scala
+++ b/app/repositories/package.scala
@@ -20,9 +20,8 @@ import model.EvaluationResults._
 import model.FlagCandidatePersistedObject.FlagCandidate
 import model.OnlineTestCommands.OnlineTestApplication
 import model.PassmarkPersistedObjects._
-import model.PersistedObjects.PersistedAnswer
 import model.command.WithdrawApplication
-import model.persisted.{ AssistanceDetails, ContactDetails }
+import model.persisted.{ AssistanceDetails, ContactDetails, QuestionnaireAnswer }
 import org.joda.time.{ DateTime, DateTimeZone, LocalDate }
 import play.modules.reactivemongo.MongoDbConnection
 import reactivemongo.api.indexes.Index
@@ -160,7 +159,7 @@ implicit object OFormatHelper {
   implicit val withdrawHandler: BSONHandler[BSONDocument, WithdrawApplication] = Macros.handler[WithdrawApplication]
   implicit val cdHandler: BSONHandler[BSONDocument, ContactDetails] = Macros.handler[ContactDetails]
   implicit val assistanceDetailsHandler: BSONHandler[BSONDocument, AssistanceDetails] = Macros.handler[AssistanceDetails]
-  implicit val answerHandler: BSONHandler[BSONDocument, PersistedAnswer] = Macros.handler[PersistedAnswer]
+  implicit val answerHandler: BSONHandler[BSONDocument, QuestionnaireAnswer] = Macros.handler[QuestionnaireAnswer]
   implicit val candidateScoresHandler: BSONHandler[BSONDocument, CandidateScores] = Macros.handler[CandidateScores]
   implicit val candidateScoreFeedback: BSONHandler[BSONDocument, CandidateScoreFeedback] = Macros.handler[CandidateScoreFeedback]
   implicit val candidateScoresAndFeedback: BSONHandler[BSONDocument, CandidateScoresAndFeedback] = Macros.handler[CandidateScoresAndFeedback]

--- a/app/scheduler/onlinetesting/ProgressSdipForFaststreamCandidateJob.scala
+++ b/app/scheduler/onlinetesting/ProgressSdipForFaststreamCandidateJob.scala
@@ -34,9 +34,6 @@ trait ProgressSdipForFaststreamCandidateJob extends SingleInstanceScheduledJob[B
   val service: Phase1TestService
 
   def tryExecute()(implicit ec: ExecutionContext): Future[Unit] = {
-    implicit val rh = EmptyRequestHeader
-    implicit val hc = new HeaderCarrier()
-
     service.nextSdipFaststreamCandidateReadyForSdipProgression.flatMap {
       case Some(o) => service.progressSdipFaststreamCandidateForSdip(o)
       case None => Future.successful(())

--- a/app/services/AuditService.scala
+++ b/app/services/AuditService.scala
@@ -16,7 +16,7 @@
 
 package services
 
-import config.MicroserviceAuditConnector
+import config.{ MicroserviceAppConfig, MicroserviceAuditConnector }
 import play.api.Play
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.play.audit.AuditExtensions.auditHeaderCarrier
@@ -45,6 +45,6 @@ trait AuditService {
 }
 
 object AuditService extends AuditService {
-  private[services] val appName = Play.current.configuration.getString("appName").get
+  private[services] val appName = MicroserviceAppConfig.appName
   private[services] val auditFacade: Audit = new Audit(appName, MicroserviceAuditConnector)
 }

--- a/app/services/applicationassessment/ApplicationAssessmentService.scala
+++ b/app/services/applicationassessment/ApplicationAssessmentService.scala
@@ -201,7 +201,7 @@ trait ApplicationAssessmentService {
   private def candidateEmailAddress(userId: String): Future[String] =
     cdRepository.find(userId).map(_.email)
 
-  private def auditNotified(event: String, application: ApplicationForNotification, emailAddress: Option[String] = None): Unit = {
+  private def auditNotified(event: String, application: ApplicationForNotification, emailAddress: Option[String]): Unit = {
     // Only log user ID (not email).
     Logger.info(s"$event for user ${application.userId}")
     auditService.logEventNoRequest(

--- a/app/services/onlinetesting/phase2/Phase2TestSelector.scala
+++ b/app/services/onlinetesting/phase2/Phase2TestSelector.scala
@@ -37,7 +37,7 @@ trait Phase2TestSelector {
     }
   }
 
-  private def getRandomScheduleWithName(currentScheduleIds: List[Int] = Nil): (String, Phase2Schedule) = {
+  private def getRandomScheduleWithName(currentScheduleIds: List[Int]): (String, Phase2Schedule) = {
     val schedules = getUnallocatedSchedules(currentScheduleIds)
 
     require(schedules.nonEmpty, "Phase2 schedule list cannot be empty")

--- a/app/services/reporting/SocioEconomicCalculator.scala
+++ b/app/services/reporting/SocioEconomicCalculator.scala
@@ -16,7 +16,7 @@
 
 package services.reporting
 
-import model.PersistedObjects.PersistedAnswer
+import model.persisted.QuestionnaireAnswer
 
 object SocioEconomicCalculator extends SocioEconomicScoreCalculator {
   val NotApplicable = 0
@@ -33,7 +33,7 @@ object SocioEconomicCalculator extends SocioEconomicScoreCalculator {
 trait SocioEconomicScoreCalculator extends Calculable {
   import services.reporting.SocioEconomicCalculator._
 
-  def calculateAsInt(answers: Map[String, PersistedAnswer]): Int = {
+  def calculateAsInt(answers: Map[String, QuestionnaireAnswer]): Int = {
     val flattenedAnswers = answers.map { case (question, answer) => question -> answer.answer.getOrElse("") }
 
     val employmentStatusSize = calculateEmploymentStatusSize(flattenedAnswers)
@@ -45,7 +45,6 @@ trait SocioEconomicScoreCalculator extends Calculable {
   }
 
   def calculate(answers: Map[String, String]): String = {
-    //    Logger.debug("## SocioEconomicScoreCalculatorTrait: " + answer)
     val employmentStatusSize = calculateEmploymentStatusSize(answers)
     if (employmentStatusSize != NotApplicable) {
       calculateSocioEconomicScore(employmentStatusSize, getTypeOfOccupation(answers))

--- a/app/services/testdata/AllocationStatusGenerator.scala
+++ b/app/services/testdata/AllocationStatusGenerator.scala
@@ -59,12 +59,6 @@ trait AllocationStatusGenerator extends ConstructiveGenerator {
       }
     }
 
-    val newStatus = if (generatorConfig.confirmedAllocation) {
-      ALLOCATION_CONFIRMED
-    } else {
-      ALLOCATION_UNCONFIRMED
-    }
-
     AllocationStatusGenerator.SlotFindingLockObj.synchronized {
       for {
         candidateInPreviousStatus <- previousStatusGenerator.generate(generationId, generatorConfig)

--- a/app/services/testdata/AwaitingAllocationStatusGenerator.scala
+++ b/app/services/testdata/AwaitingAllocationStatusGenerator.scala
@@ -39,6 +39,7 @@ trait AwaitingAllocationStatusGenerator extends ConstructiveGenerator {
 
   def generate(generationId: Int, generatorConfig: GeneratorConfig)(implicit hc: HeaderCarrier, rh: RequestHeader) = {
 
+    /*
     def getEvaluationResult(candidate: DataGenerationResponse): RuleCategoryResult = {
       RuleCategoryResult(
         generatorConfig.loc1scheme1Passmark.getOrElse(Random.passmark),
@@ -47,7 +48,7 @@ trait AwaitingAllocationStatusGenerator extends ConstructiveGenerator {
         None,
         None
       )
-    }
+    }*/
 
     for {
       candidateInPreviousStatus <- previousStatusGenerator.generate(generationId, generatorConfig)

--- a/app/services/testdata/CreatedStatusGenerator.scala
+++ b/app/services/testdata/CreatedStatusGenerator.scala
@@ -18,7 +18,6 @@ package services.testdata
 
 import connectors.{ AuthProviderClient, ExchangeObjects }
 import model.ApplicationRoute
-import model.PersistedObjects.{ PersistedAnswer, PersistedQuestion }
 import play.api.mvc.RequestHeader
 import repositories._
 import repositories.application.GeneralApplicationRepository

--- a/app/services/testdata/InProgressQuestionnaireStatusGenerator.scala
+++ b/app/services/testdata/InProgressQuestionnaireStatusGenerator.scala
@@ -16,13 +16,13 @@
 
 package services.testdata
 
-import model.PersistedObjects.{ PersistedAnswer, PersistedQuestion }
 import play.api.mvc.RequestHeader
 import repositories._
 import repositories.application.GeneralApplicationRepository
 import services.testdata.faker.DataFaker._
 import uk.gov.hmrc.play.http.HeaderCarrier
 import model.command.testdata.GeneratorConfig
+import model.persisted.{ QuestionnaireAnswer, QuestionnaireQuestion }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -42,8 +42,8 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
     val didYouLiveInUkBetween14and18Answer = Random.yesNo
     def getWhatWasYourHomePostCodeWhenYouWere14 = {
       if (didYouLiveInUkBetween14and18Answer == "Yes") {
-        Some(PersistedQuestion("What was your home postcode when you were 14?",
-          PersistedAnswer(Some(Random.homePostcode), None, None)))
+        Some(QuestionnaireQuestion("What was your home postcode when you were 14?",
+          QuestionnaireAnswer(Some(Random.homePostcode), None, None)))
       } else {
         None
       }
@@ -51,8 +51,8 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getSchoolName14to16Answer = {
       if (didYouLiveInUkBetween14and18Answer == "Yes") {
-        Some(PersistedQuestion("Aged 14 to 16 what was the name of your school?",
-          PersistedAnswer(Some(Random.age14to16School), None, None)))
+        Some(QuestionnaireQuestion("Aged 14 to 16 what was the name of your school?",
+          QuestionnaireAnswer(Some(Random.age14to16School), None, None)))
       } else {
         None
       }
@@ -60,8 +60,8 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getSchoolName16to18Answer = {
       if (didYouLiveInUkBetween14and18Answer == "Yes") {
-        Some(PersistedQuestion("Aged 16 to 18 what was the name of your school?",
-          PersistedAnswer(Some(Random.age16to18School), None, None)))
+        Some(QuestionnaireQuestion("Aged 16 to 18 what was the name of your school?",
+          QuestionnaireAnswer(Some(Random.age16to18School), None, None)))
       } else {
         None
       }
@@ -69,8 +69,8 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getFreeSchoolMealsAnswer = {
       if (didYouLiveInUkBetween14and18Answer == "Yes") {
-        Some(PersistedQuestion("Were you at any time eligible for free school meals?",
-          PersistedAnswer(Some(Random.yesNoPreferNotToSay), None, None)))
+        Some(QuestionnaireQuestion("Were you at any time eligible for free school meals?",
+          QuestionnaireAnswer(Some(Random.yesNoPreferNotToSay), None, None)))
       } else {
         None
       }
@@ -78,16 +78,16 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getHaveDegreeAnswer = {
       if (generatorConfig.isCivilServant) {
-        Some(PersistedQuestion("Do you have a degree?",
-          PersistedAnswer(Some(if (generatorConfig.hasDegree) { "Yes" } else { "No" }), None, None))
+        Some(QuestionnaireQuestion("Do you have a degree?",
+          QuestionnaireAnswer(Some(if (generatorConfig.hasDegree) { "Yes" } else { "No" }), None, None))
         )
       } else { None }
     }
 
     def getUniversityAnswer = {
       if (generatorConfig.hasDegree) {
-        Some(PersistedQuestion("What is the name of the university you received your degree from?",
-          PersistedAnswer(Some(Random.university._2), None, None)))
+        Some(QuestionnaireQuestion("What is the name of the university you received your degree from?",
+          QuestionnaireAnswer(Some(Random.university._2), None, None)))
       } else {
         None
       }
@@ -95,8 +95,8 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getUniversityDegreeCategoryAnswer = {
       if (generatorConfig.hasDegree) {
-        Some(PersistedQuestion("Which category best describes your degree?",
-          PersistedAnswer(Some(Random.degreeCategory._2), None, None)))
+        Some(QuestionnaireQuestion("Which category best describes your degree?",
+          QuestionnaireAnswer(Some(Random.degreeCategory._2), None, None)))
       } else {
         None
       }
@@ -106,18 +106,18 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getParentsOccupationDetail(parentsOccupation: String) = {
       if (parentsOccupation == "Employed") {
-        Some(PersistedQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
-          PersistedAnswer(Some(Random.parentsOccupationDetails), None, None)))
+        Some(QuestionnaireQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
+          QuestionnaireAnswer(Some(Random.parentsOccupationDetails), None, None)))
       } else {
-        Some(PersistedQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
-          PersistedAnswer(Some(parentsOccupation), None, None)))
+        Some(QuestionnaireQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
+          QuestionnaireAnswer(Some(parentsOccupation), None, None)))
       }
     }
 
     def getEmployeedOrSelfEmployeed(parentsOccupation: String) = {
       if (parentsOccupation == "Employed") {
-        Some(PersistedQuestion("Did they work as an employee or were they self-employed?",
-          PersistedAnswer(Some(Random.employeeOrSelf), None, None)))
+        Some(QuestionnaireQuestion("Did they work as an employee or were they self-employed?",
+          QuestionnaireAnswer(Some(Random.employeeOrSelf), None, None)))
       } else {
         None
       }
@@ -125,8 +125,8 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getSizeParentsEmployeer(parentsOccupation: String) = {
       if (parentsOccupation == "Employed") {
-        Some(PersistedQuestion("Which size would best describe their place of work?",
-          PersistedAnswer(Some(Random.sizeParentsEmployeer), None, None)))
+        Some(QuestionnaireQuestion("Which size would best describe their place of work?",
+          QuestionnaireAnswer(Some(Random.sizeParentsEmployeer), None, None)))
       } else {
         None
       }
@@ -134,19 +134,19 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
 
     def getSuperviseEmployees(parentsOccupation: String) = {
       if (parentsOccupation == "Employed") {
-        Some(PersistedQuestion("Did they supervise employees?",
-          PersistedAnswer(Some(Random.yesNoPreferNotToSay), None, None)))
+        Some(QuestionnaireQuestion("Did they supervise employees?",
+          QuestionnaireAnswer(Some(Random.yesNoPreferNotToSay), None, None)))
       } else {
         None
       }
     }
 
     def getAllQuestionnaireQuestions(parentsOccupation: String) = List(
-      Some(PersistedQuestion("I understand this won't affect my application", PersistedAnswer(Some(Random.yesNo), None, None))),
-      Some(PersistedQuestion("What is your gender identity?", PersistedAnswer(Some(Random.gender), None, None))),
-      Some(PersistedQuestion("What is your sexual orientation?", PersistedAnswer(Some(Random.sexualOrientation), None, None))),
-      Some(PersistedQuestion("What is your ethnic group?", PersistedAnswer(Some(Random.ethnicGroup), None, None))),
-      Some(PersistedQuestion("Did you live in the UK between the ages of 14 and 18?", PersistedAnswer(
+      Some(QuestionnaireQuestion("I understand this won't affect my application", QuestionnaireAnswer(Some(Random.yesNo), None, None))),
+      Some(QuestionnaireQuestion("What is your gender identity?", QuestionnaireAnswer(Some(Random.gender), None, None))),
+      Some(QuestionnaireQuestion("What is your sexual orientation?", QuestionnaireAnswer(Some(Random.sexualOrientation), None, None))),
+      Some(QuestionnaireQuestion("What is your ethnic group?", QuestionnaireAnswer(Some(Random.ethnicGroup), None, None))),
+      Some(QuestionnaireQuestion("Did you live in the UK between the ages of 14 and 18?", QuestionnaireAnswer(
         Some(didYouLiveInUkBetween14and18Answer), None, None))
       ),
       getWhatWasYourHomePostCodeWhenYouWere14,
@@ -156,8 +156,8 @@ trait InProgressQuestionnaireStatusGenerator extends ConstructiveGenerator {
       getHaveDegreeAnswer,
       getUniversityAnswer,
       getUniversityDegreeCategoryAnswer,
-      Some(PersistedQuestion("Do you have a parent or guardian that has completed a university degree course or equivalent?",
-        PersistedAnswer(Some(Random.yesNoPreferNotToSay), None, None))
+      Some(QuestionnaireQuestion("Do you have a parent or guardian that has completed a university degree course or equivalent?",
+        QuestionnaireAnswer(Some(Random.yesNoPreferNotToSay), None, None))
       ),
       getParentsOccupationDetail(parentsOccupation),
       getEmployeedOrSelfEmployeed(parentsOccupation),

--- a/it/repositories/QuestionnaireRepositorySpec.scala
+++ b/it/repositories/QuestionnaireRepositorySpec.scala
@@ -16,7 +16,7 @@
 
 package repositories
 
-import model.PersistedObjects.{PersistedAnswer, PersistedQuestion}
+import model.persisted.{ QuestionnaireAnswer, QuestionnaireQuestion }
 import model.report.QuestionnaireReportItem
 import org.mockito.ArgumentMatchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
@@ -31,16 +31,19 @@ class QuestionnaireRepositorySpec extends MongoRepositorySpec with MockitoSugar 
   "The Questionnaire Repo" should {
     "create collection, append questions to the application and overwrite existing questions" in new TestFixture {
       val applicationId = System.currentTimeMillis() + ""
-      questionnaireRepo.addQuestions(applicationId, List(PersistedQuestion("what?", PersistedAnswer(Some("nothing"), None, None)))).futureValue
+      questionnaireRepo.addQuestions(applicationId, List(QuestionnaireQuestion("what?",
+        QuestionnaireAnswer(Some("nothing"), None, None)))).futureValue
       val result = questionnaireRepo.find(applicationId).futureValue
       result.size mustBe 1
 
-      questionnaireRepo.addQuestions(applicationId, List(PersistedQuestion("what?", PersistedAnswer(Some("nada"), None, None)))).futureValue
+      questionnaireRepo.addQuestions(applicationId, List(QuestionnaireQuestion("what?",
+        QuestionnaireAnswer(Some("nada"), None, None)))).futureValue
       val result1 = questionnaireRepo.find(applicationId).futureValue
       result1.size mustBe 1
       result1.head.answer.answer must be(Some("nada"))
 
-      questionnaireRepo.addQuestions(applicationId, List(PersistedQuestion("where?", PersistedAnswer(None, None, Some(true))))).futureValue
+      questionnaireRepo.addQuestions(applicationId, List(QuestionnaireQuestion("where?",
+        QuestionnaireAnswer(None, None, Some(true))))).futureValue
       val result2 = questionnaireRepo.find(applicationId).futureValue
       result2.size mustBe 2
     }
@@ -48,10 +51,11 @@ class QuestionnaireRepositorySpec extends MongoRepositorySpec with MockitoSugar 
     "find questions should return a map of questions/answers ignoring the non answered ones" in new TestFixture {
       val applicationId = System.currentTimeMillis() + ""
 
-      val emptyAnswer = PersistedAnswer(None, None, Some(true))
+      val emptyAnswer = QuestionnaireAnswer(None, None, Some(true))
 
-      questionnaireRepo.addQuestions(applicationId, List(PersistedQuestion("what?", PersistedAnswer(Some("nada"), None, None)))).futureValue
-      questionnaireRepo.addQuestions(applicationId, List(PersistedQuestion("where?", emptyAnswer))).futureValue
+      questionnaireRepo.addQuestions(applicationId, List(QuestionnaireQuestion("what?",
+        QuestionnaireAnswer(Some("nada"), None, None)))).futureValue
+      questionnaireRepo.addQuestions(applicationId, List(QuestionnaireQuestion("where?", emptyAnswer))).futureValue
       val result2 = questionnaireRepo.findQuestions(applicationId).futureValue
 
       result2.keys.size mustBe 2
@@ -114,27 +118,30 @@ class QuestionnaireRepositorySpec extends MongoRepositorySpec with MockitoSugar 
     val applicationId2 = "123"
     val applicationId3 = "partiallyCompleteId"
     val submittedQuestionnaire1 = List(
-      PersistedQuestion("What is your gender identity?", PersistedAnswer(Some("Male"), None, None)),
-      PersistedQuestion("What is your sexual orientation?", PersistedAnswer(Some("Straight"), None, None)),
-      PersistedQuestion("What is your ethnic group?", PersistedAnswer(Some("Black"), None, None)),
-      PersistedQuestion("What is the name of the university you received your degree from?", PersistedAnswer(Some("W01-USW"), None, None)),
-      PersistedQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
-        PersistedAnswer(Some("Unemployed"), None, None))
+      QuestionnaireQuestion("What is your gender identity?", QuestionnaireAnswer(Some("Male"), None, None)),
+      QuestionnaireQuestion("What is your sexual orientation?", QuestionnaireAnswer(Some("Straight"), None, None)),
+      QuestionnaireQuestion("What is your ethnic group?", QuestionnaireAnswer(Some("Black"), None, None)),
+      QuestionnaireQuestion("What is the name of the university you received your degree from?",
+        QuestionnaireAnswer(Some("W01-USW"), None, None)),
+      QuestionnaireQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
+        QuestionnaireAnswer(Some("Unemployed"), None, None))
     )
     val submittedQuestionnaire2 = List(
-      PersistedQuestion("What is your gender identity?", PersistedAnswer(Some("Female"), None, None)),
-      PersistedQuestion("What is your sexual orientation?", PersistedAnswer(Some("Lesbian"), None, None)),
-      PersistedQuestion("What is your ethnic group?", PersistedAnswer(Some("White"), None, None)),
-      PersistedQuestion("What is the name of the university you received your degree from?", PersistedAnswer(Some("W17-WARR"), None, None)),
-      PersistedQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
-        PersistedAnswer(Some("Modern professional"), None, None)),
-      PersistedQuestion("Did they work as an employee or were they self-employed?", PersistedAnswer(Some("Part-time employed"), None, None)),
-      PersistedQuestion("Which size would best describe their place of work?", PersistedAnswer(Some("Large (26-500)"), None, None))
+      QuestionnaireQuestion("What is your gender identity?", QuestionnaireAnswer(Some("Female"), None, None)),
+      QuestionnaireQuestion("What is your sexual orientation?", QuestionnaireAnswer(Some("Lesbian"), None, None)),
+      QuestionnaireQuestion("What is your ethnic group?", QuestionnaireAnswer(Some("White"), None, None)),
+      QuestionnaireQuestion("What is the name of the university you received your degree from?",
+        QuestionnaireAnswer(Some("W17-WARR"), None, None)),
+      QuestionnaireQuestion("When you were 14, what kind of work did your highest-earning parent or guardian do?",
+        QuestionnaireAnswer(Some("Modern professional"), None, None)),
+      QuestionnaireQuestion("Did they work as an employee or were they self-employed?",
+        QuestionnaireAnswer(Some("Part-time employed"), None, None)),
+      QuestionnaireQuestion("Which size would best describe their place of work?", QuestionnaireAnswer(Some("Large (26-500)"), None, None))
     )
     val partiallyCompleteQuestionnaire = List(
-      PersistedQuestion("What is your gender identity?", PersistedAnswer(Some("Female"), None, None)),
-      PersistedQuestion("What is your sexual orientation?", PersistedAnswer(Some("Lesbian"), None, None)),
-      PersistedQuestion("What is your ethnic group?", PersistedAnswer(Some("White"), None, None))
+      QuestionnaireQuestion("What is your gender identity?", QuestionnaireAnswer(Some("Female"), None, None)),
+      QuestionnaireQuestion("What is your sexual orientation?", QuestionnaireAnswer(Some("Lesbian"), None, None)),
+      QuestionnaireQuestion("What is your ethnic group?", QuestionnaireAnswer(Some("White"), None, None))
     )
 
     val socioEconomicCalculator = mock[SocioEconomicScoreCalculator]

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -58,7 +58,9 @@ trait MicroService {
       retrieveManaged := true,
       scalacOptions += "-feature",
       // Currently don't enable warning in value discard in tests until ScalaTest 3
-      scalacOptions in (Compile, compile) += "-Ywarn-value-discard")
+      scalacOptions in(Compile, compile) += "-Ywarn-value-discard",
+      scalacOptions in(Compile, compile) += "-Xlint:-missing-interpolator,_",
+      scalacOptions in(Compile, compile) += "-Ywarn-unused")
     .settings(sources in (Compile, doc) := Seq.empty)
     .settings(HeaderPlugin.settingsFor(IntegrationTest))
     .configs(IntegrationTest)

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -54,6 +54,8 @@ private object AppDependencies {
     "org.webjars" % "bootstrap" % "3.1.1",
     "org.webjars" % "jquery" % "1.11.0",
     "net.ceedubs" %% "ficus" % ficus,
+    compilerPlugin("com.github.ghik" %% "silencer-plugin" % "0.5"),
+    "com.github.ghik" %% "silencer-lib" % "0.5",
     "org.yaml" % "snakeyaml" % "1.16",
     "com.jsuereth" %% "scala-arm" % "1.4",
     filters,

--- a/test/connectors/CubiksGatewayClientSpec.scala
+++ b/test/connectors/CubiksGatewayClientSpec.scala
@@ -100,24 +100,6 @@ class CubiksGatewayClientSpec extends UnitSpec with ShortTimeout {
     }
   }
 
-  "download pdf report" should {
-    "return a ConnectorException when cubiks gateway returns HTTP status Bad Gateway" in new GatewayTest {
-      setupPDFWSMock()
-      val result = cubiksGatewayClient.downloadPdfReport(44444)
-      result.failed.futureValue mustBe a[ConnectorException]
-    }
-    "throw an Exception when there is an exception when calling cubiks gateway" in new GatewayTest {
-      setupPDFWSMock()
-      val result = cubiksGatewayClient.downloadPdfReport(55555)
-      result.failed.futureValue mustBe an[Exception]
-    }
-    "request a report" in new GatewayTest {
-      setupPDFWSMock()
-      val result = cubiksGatewayClient.downloadPdfReport(66666)
-      result.futureValue must be(samplePDFValue)
-    }
-  }
-
   trait GatewayTest {
     implicit val hc = HeaderCarrier()
     val mockWSHttp = mock[WSHttp]

--- a/test/mocks/QuestionnaireInMemoryRepository.scala
+++ b/test/mocks/QuestionnaireInMemoryRepository.scala
@@ -16,23 +16,23 @@
 
 package mocks
 
-import model.PersistedObjects.{ PersistedAnswer, PersistedQuestion }
+import model.persisted.{ QuestionnaireAnswer, QuestionnaireQuestion }
 import model.report.QuestionnaireReportItem
 import repositories.QuestionnaireRepository
 
 import scala.concurrent.Future
 
-object QuestionnaireInMemoryRepository extends QuestionnaireRepository with InMemoryStorage[List[PersistedQuestion]] {
+object QuestionnaireInMemoryRepository extends QuestionnaireRepository with InMemoryStorage[List[QuestionnaireQuestion]] {
 
-  override def addQuestions(applicationId: String, questions: List[PersistedQuestion]): Future[Unit] = {
+  override def addQuestions(applicationId: String, questions: List[QuestionnaireQuestion]): Future[Unit] = {
     inMemoryRepo.put(applicationId, inMemoryRepo.getOrElse(applicationId, List()) ++ questions)
     Future.successful(())
   }
 
   override def notFound(applicationId: String) = throw QuestionnaireNotFound(applicationId)
 
-  override def findQuestions(applicationId: String): Future[Map[String, PersistedAnswer]] =
-    Future.successful(Map.empty[String, PersistedAnswer])
+  override def findQuestions(applicationId: String): Future[Map[String, QuestionnaireAnswer]] =
+    Future.successful(Map.empty[String, QuestionnaireAnswer])
 
   override def findAllForDiversityReport: Future[Map[String, QuestionnaireReportItem]] =
     Future.successful(Map.empty[String, QuestionnaireReportItem])


### PR DESCRIPTION
- Added 'silencer' (@silent) to suppress warnings we can't do anything about (because of HMRC libraries or structural changes that we're not going to make just yet, mainly use of Play.application)
- Removed unused vars, default arguments and methods, added flags to the compiler to tell us about them as warnings in future
- Moved Question/Answer out of the PersistedObjects mega file (as it's deprecated and triggers a warning) to become QuestionnaireQuestion and QuestionnaireAnswer

I've run acceptance but of course encourage you to do the same kind reviewer :-)