### PR TITLE
FSET 1354: Display the availability schedule for assessors/qacs

### DIFF
--- a/app/controllers/AssessmentScheduleController.scala
+++ b/app/controllers/AssessmentScheduleController.scala
@@ -69,16 +69,16 @@ trait AssessmentScheduleController extends BaseController {
 
   def getAssessmentScheduleDatesByRegion(region: String): Action[AnyContent] = Action.async { implicit request =>
      acRepository.assessmentCentreCapacities.map { schedule =>
-       val toRet = schedule
-         .filter(location => location.locationName == region)
-         .flatMap(location =>
-           location.venues.flatMap(venue =>
+       val dates = schedule
+         .filter(scheduleRegion => scheduleRegion.locationName == region)
+         .flatMap(scheduleRegion =>
+           scheduleRegion.venues.flatMap(venue =>
              venue.capacityDates.map(capacityDates =>
                capacityDates.date
              )
            )
          ).distinct.sorted
-       Ok(Json.toJson(toRet))
+       Ok(Json.toJson(dates))
      }
   }
 

--- a/app/controllers/AssessmentScheduleController.scala
+++ b/app/controllers/AssessmentScheduleController.scala
@@ -1,0 +1,427 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import java.io.UnsupportedEncodingException
+import java.net.URLDecoder
+
+import com.github.nscala_time.time.OrderingImplicits.LocalDateOrdering
+import common.FutureEx
+import connectors.AssessmentScheduleExchangeObjects._
+import connectors.ExchangeObjects.AllocationDetails
+import connectors.{ CSREmailClient, EmailClient }
+import model.AssessmentScheduleCommands.ApplicationForAssessmentAllocationResult
+import model.AssessmentScheduleCommands.Implicits.ApplicationForAssessmentAllocationResultFormats
+import model.Commands.Implicits.applicationAssessmentFormat
+import model.Exceptions.NotFoundException
+import model.{ Commands, ProgressStatuses }
+import org.joda.time.LocalDate
+import play.api.libs.json.{ JsValue, Json }
+import play.api.mvc.{ Action, AnyContent, Result }
+import repositories.AssessmentCentreLocation.assessmentCentreVenueFormat
+import repositories._
+import repositories.application._
+import services.AuditService
+import uk.gov.hmrc.play.microservice.controller.BaseController
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.Try
+
+object AssessmentScheduleController extends AssessmentScheduleController {
+  // val aaRepository: AssessmentCentreAllocationMongoRepository = assessmentCentreAllocationRepository
+  val acRepository = AssessmentCentreYamlRepository
+  val aRepository: GeneralApplicationMongoRepository = applicationRepository
+  // val otRepository: OnlineTestMongoRepository = onlineTestRepository
+  val auditService = AuditService
+  // val pdRepository: PersonalDetailsRepository = personalDetailsRepository
+  // val cdRepository: ContactDetailsRepository = contactDetailsRepository
+  val emailClient = CSREmailClient
+  // val aaService = AssessmentCentreService
+  // val assessmentScoresService = AssessorAssessmentScoresService
+}
+
+trait AssessmentScheduleController extends BaseController {
+  // val aaRepository: AssessmentCentreAllocationRepository
+  val acRepository: AssessmentCentreRepository
+  val aRepository: GeneralApplicationRepository
+  // val otRepository: OnlineTestRepository
+  val auditService: AuditService
+  // val pdRepository: PersonalDetailsRepository
+  // val cdRepository: ContactDetailsRepository
+  val emailClient: EmailClient
+  // val aaService: AssessmentCentreService
+  // val assessmentScoresService: AssessmentCentreScoresService
+
+  def getAssessmentScheduleDatesByRegion(region: String): Action[AnyContent] = Action.async { implicit request =>
+     acRepository.assessmentCentreCapacities.map { schedule =>
+       val toRet = schedule
+         .filter(location => location.locationName == region)
+         .flatMap(location =>
+           location.venues.flatMap(venue =>
+             venue.capacityDates.map(capacityDates =>
+               capacityDates.date
+             )
+           )
+         ).distinct.sorted
+       Ok(Json.toJson(toRet))
+     }
+  }
+
+  /*
+  private def calculateUsedCapacity(assessments: Option[List[AssessmentCentreAllocation]], sessionCapacity: Int,
+    minViableAttendees: Int, preferredAttendeeMargin: Int): UsedCapacity = {
+    assessments.map { sessionSlots =>
+      UsedCapacity(sessionSlots.size, sessionSlots.count(x => x.confirmed), minViableAttendees, preferredAttendeeMargin)
+    }.getOrElse(
+      UsedCapacity(usedCapacity = 0, confirmedAttendees = 0, minViableAttendees, preferredAttendeeMargin)
+    )
+  }
+
+  def getAssessmentSchedule: Action[AnyContent] = Action.async { implicit request =>
+    val assessments = aaRepository.findAll.map(_.groupBy(x => (x.venue, x.date, x.session)))
+
+    for {
+      assessmentMap <- assessments
+      assessmentCentreCapacities <- acRepository.assessmentCentreCapacities
+    } yield {
+      val schedule = Schedule(
+        assessmentCentreCapacities.map(assessmentCentreCapacity =>
+          Location(
+            assessmentCentreCapacity.locationName,
+            assessmentCentreCapacity.venues.map(venue =>
+              Venue(
+                venue.venueName,
+                venue.capacityDates.map(capacityDate =>
+                  UsedCapacityDate(
+                    capacityDate.date,
+                    calculateUsedCapacity(
+                      assessmentMap.get((venue.venueName, capacityDate.date, "AM")),
+                      capacityDate.amCapacity, capacityDate.amMinViableAttendees, capacityDate.amPreferredAttendeeMargin
+                    ),
+                    calculateUsedCapacity(
+                      assessmentMap.get((venue.venueName, capacityDate.date, "PM")),
+                      capacityDate.pmCapacity, capacityDate.pmMinViableAttendees, capacityDate.pmPreferredAttendeeMargin
+                    )
+                  ))
+              ))
+          ))
+      )
+      Ok(Json.toJson(schedule))
+    }
+  }
+
+  def getAssessmentCentreCapacities(venue: String): Action[AnyContent] = Action.async { implicit request =>
+    val venueDecoded = URLDecoder.decode(venue, "UTF-8")
+    val today = LocalDate.now()
+
+    acRepository.assessmentCentreCapacities.map { apps =>
+      val result = apps.flatMap(_.venues).find(_.venueName == venueDecoded).map { venue =>
+        venue.copy(capacityDates = venue.capacityDates.filterNot(d => d.date.isBefore(today)))
+      }
+
+      result match {
+        case Some(c) => Ok(Json.toJson(c))
+        case None => NotFound(s"Cannot find capacity for the venue: $venue")
+      }
+    }
+  }
+
+  private def joinApplicationsAndApplicationAssessments(
+    assessmentsFut: Future[List[AssessmentCentreAllocation]],
+    candidatesFut: Future[List[Commands.Candidate]]
+  ) = {
+    for {
+      assessments <- assessmentsFut
+      candidates <- candidatesFut
+    } yield {
+      assessments.flatMap { assessment =>
+        candidates.collect {
+          case candidate if candidate.applicationId.contains(assessment.applicationId) => (assessment, candidate)
+        }
+      }
+    }
+  }
+
+  def getApplicationForAssessmentAllocation(assessmentCenterLocation: String, start: Int, end: Int): Action[AnyContent] = Action.async {
+    implicit request =>
+      aRepository.findApplicationsForAssessmentAllocation(List(assessmentCenterLocation), start, end) map { apps =>
+        Ok(Json.toJson(apps))
+      }
+  }
+
+  def getAllocationsForVenue(venue: String): Action[AnyContent] = Action.async { implicit request =>
+    val venueDecoded = URLDecoder.decode(venue, "UTF-8")
+    val assessments = aaRepository.findAllForVenue(venueDecoded).map(_.groupBy(x => x.session))
+
+    for {
+      assessmentMap <- assessments
+    } yield {
+      val amAssessments = assessmentMap.get("AM").map(x => x.groupBy(_.date)).getOrElse(Map())
+      val pmAssessments = assessmentMap.get("PM").map(x => x.groupBy(_.date)).getOrElse(Map())
+
+      val amBookedSlots = amAssessments.mapValues { x => x.map(_.slot) }
+      val pmBookedSlots = pmAssessments.mapValues { x => x.map(_.slot) }
+
+      val dates = (amBookedSlots.keys ++ pmBookedSlots.keys).toList.distinct
+      val venueAllocations = dates.map { d =>
+        VenueAllocation(d, amBookedSlots.getOrElse(d, List()), pmBookedSlots.getOrElse(d, List()))
+      }
+      Ok(Json.toJson(venueAllocations))
+    }
+  }
+
+  def allocate(): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    def allocateCandidate(allocation: AssessmentCentreAllocation): Future[Unit] = {
+      if (allocation.confirmed) {
+        otRepository.saveCandidateAllocationStatus(allocation.applicationId, AllocationConfirmed, None)
+      } else {
+        val expireDate = allocation.expireDate
+
+        for {
+          pd <- pdRepository.findPersonalDetailsWithUserId(allocation.applicationId)
+          cd <- cdRepository.find(pd.userId)
+          _ <- emailClient.sendConfirmAttendance(cd.email, pd.preferredName, allocation.assessmentDateTime, expireDate)
+          _ <- otRepository.saveCandidateAllocationStatus(allocation.applicationId, AllocationUnconfirmed, Some(expireDate))
+        } yield {
+          auditService.logEvent("AssessmentCentreAllocationUnconfirmed")
+        }
+      }
+    }
+
+    withJsonBody[List[AssessmentCentreAllocation]] { apps =>
+      val errorListFuture = aaRepository.create(apps)
+
+      val result = errorListFuture.flatMap { errorList =>
+        val allocationsFuture = apps.filterNot(errorList.contains(_)).map { successfulAllocation =>
+          allocateCandidate(successfulAllocation)
+        }
+
+        Future.sequence(allocationsFuture).map { _ =>
+          errorList
+        }
+      }
+
+      result map {
+        case errorList if errorList.isEmpty => Created
+        case errorList =>
+          Ok(Json.toJson(errorList))
+      }
+    }
+  }
+
+  def allocationStatus(applicationId: String): Action[AnyContent] = Action.async { implicit request =>
+    import connectors.ExchangeObjects.Implicits._
+
+    acRepository.assessmentCentreCapacities.flatMap { assessmentCentres =>
+
+      for {
+        assessmentF <- aaRepository.find(applicationId)
+        expiryDate <- aRepository.allocationExpireDateByApplicationId(applicationId)
+      } yield {
+        assessmentF match {
+          case Some(assessment) => {
+            val (locationName, venue) = assessmentCentres.flatMap(capacity =>
+              capacity.venues.find(_.venueName == assessment.venue).map(capacity.locationName -> _)).head
+
+            Ok(Json.toJson(AllocationDetails(locationName, venue.venueDescription, assessment.assessmentDateTime, expiryDate)))
+          }
+          case _ => NotFound
+        }
+      }
+    }
+
+  }
+
+  def confirmAllocation(applicationId: String): Action[AnyContent] = Action.async { implicit request =>
+
+    aaRepository.confirmAllocation(applicationId).flatMap { _ =>
+      aRepository.updateStatus(applicationId, AllocationConfirmed).map { _ =>
+        auditService.logEvent("AssessmentCentreAllocationConfirmed")
+        Ok("")
+      }
+    }
+  }
+
+  private def generatePaddedVenueDaySessionCandidateList(
+    assessmentsInSession: Map[String, List[(Commands.AssessmentCentreAllocation, Commands.Candidate)]],
+    capacities: Future[AssessmentCentreVenueCapacityDate]
+  ) = {
+
+    val capacityMap = Map[String, Future[Int]](
+      "AM" -> capacities.map { _.amCapacity - assessmentsInSession.get("AM").map(_.length).getOrElse(0) },
+      "PM" -> capacities.map { _.pmCapacity - assessmentsInSession.get("PM").map(_.length).getOrElse(0) }
+    )
+
+    capacityMap.keys.map { sessionName =>
+      val sessionList = assessmentsInSession.getOrElse(sessionName, Nil).map {
+        case (applicationAssessment, applicationCandidate) =>
+          Some(VenueDaySessionCandidate(
+            applicationAssessment.slot,
+            applicationCandidate.userId,
+            applicationAssessment.applicationId,
+            applicationCandidate.firstName.get,
+            applicationCandidate.lastName.get,
+            confirmed = applicationAssessment.confirmed
+          ))
+      }
+
+      sessionName -> capacityMap(sessionName).map { sessionSlotsAvailable =>
+        sessionList ++ List.fill(sessionSlotsAvailable)(None) //Filling up the empty slots
+      }
+    }.toMap
+  }
+
+  private def getVenueDayDetails(venueEncoded: String, dateEncoded: String)(
+    resultGenerator: (String, LocalDate, Future[VenueDayDetails]) => Future[Result]
+  ) = {
+    val date = Try(LocalDate.parse(dateEncoded)).getOrElse(
+      throw new IllegalArgumentException("Invalid date passed")
+    )
+
+    val venue = Try(URLDecoder.decode(venueEncoded, "UTF-8")).getOrElse(
+      throw new UnsupportedEncodingException("Invalid encoding in passed venue name ")
+    )
+
+    val capacities = acRepository.assessmentCentreCapacityDate(venue, date)
+
+    val assessmentsForVenueDate = aaRepository.findAllForDate(venue, date)
+
+    val applicationRecordsForAllAssessments = assessmentsForVenueDate.map(_.map(_.applicationId)).flatMap(aRepository.find)
+
+    val applicationRecordsForAllAssessmentsWithStatus = applicationRecordsForAllAssessments.flatMap { applications =>
+      Future.sequence(applications.map { application =>
+        aRepository.findProgress(application.applicationId.get).map { progressStatus =>
+          ApplicationStatusOrder.getStatus(progressStatus)
+        }.map { applicationStatus =>
+          (application, applicationStatus)
+        }
+      })
+    }
+
+    val applicationRecordsForAllAssessmentsNotWithdrawn = applicationRecordsForAllAssessmentsWithStatus.map { list =>
+      list.filter(_._2 != "withdrawn").map(_._1)
+    }
+
+    val assessmentApplicationsGroupedBySessionFut = joinApplicationsAndApplicationAssessments(
+      assessmentsForVenueDate,
+      applicationRecordsForAllAssessmentsNotWithdrawn
+    ).map(_.groupBy(x => x._1.session))
+
+    assessmentApplicationsGroupedBySessionFut.flatMap { assessmentApplicationsGroupedBySession =>
+
+      val filledOrPaddedWithEmptySlotsToMaxCapacityMap =
+        generatePaddedVenueDaySessionCandidateList(assessmentApplicationsGroupedBySession, capacities)
+
+      val venueDateDetailsFut = for {
+        amListPadded <- filledOrPaddedWithEmptySlotsToMaxCapacityMap("AM")
+        pmListPadded <- filledOrPaddedWithEmptySlotsToMaxCapacityMap("PM")
+      } yield {
+        VenueDayDetails(amListPadded, pmListPadded)
+      }
+
+      resultGenerator(venue, date, venueDateDetailsFut)
+    }
+  }
+
+  def getVenueDayCandidateScheduleWithDetails(venueEncoded: String, dateEncoded: String): Action[AnyContent] = Action.async { implicit request =>
+
+    getVenueDayDetails(venueEncoded, dateEncoded) { (venue, date, detailsF) =>
+      detailsF.flatMap { venueDateDetails =>
+        val amCandidates = venueDateDetails.amSession
+        val pmCandidates = venueDateDetails.pmSession
+
+        def toExchangeObjects(list: List[Option[VenueDaySessionCandidate]], session: String) = list.map(_.map { c =>
+          (c.userId, c.applicationId,
+            ScheduledCandidateDetail(c.slotNumber, c.firstName, c.lastName, None, None, None, venue, session,
+              date, if (c.confirmed) "Confirmed" else "Unconfirmed"))
+        })
+
+        val candidates = (toExchangeObjects(amCandidates, "AM") ++ toExchangeObjects(pmCandidates, "PM")).flatten
+
+        FutureEx.traverseSerial(candidates) {
+          case (userId, applicationId, candidate) =>
+
+            val cdF = cdRepository.find(userId)
+            val pdF = pdRepository.find(applicationId)
+
+            for {
+              contact <- cdF
+              details <- pdF
+            } yield {
+              candidate.copy(preferredName = Some(details.preferredName), email = Some(contact.email), phone = contact.phone)
+            }
+        }.map { list =>
+          Ok(Json.toJson(list))
+        }
+
+      }
+    }
+
+  }
+
+  def getVenueDayCandidateSchedule(venueEncoded: String, dateEncoded: String): Action[AnyContent] = Action.async { implicit request =>
+    getVenueDayDetails(venueEncoded, dateEncoded)((_, _, detailsFuture) => detailsFuture.map { venueDateDetails =>
+      Ok(Json.toJson(venueDateDetails))
+    })
+  }
+
+  def getApplicationAssessment(applicationId: String): Action[AnyContent] = Action.async { implicit request =>
+    aaRepository.find(applicationId).map {
+      case Some(assessment) => Ok(Json.toJson(assessment))
+      case _ => NotFound("No application assessment could be found")
+    }
+  }
+
+  def deleteApplicationAssessment(applicationId: String): Action[AnyContent] = Action.async { implicit request =>
+    aRepository.findProgress(applicationId).flatMap { result =>
+      ApplicationStatusOrder.getStatus(result) match {
+        case ProgressStatuses.AssessmentScoresAcceptedProgress =>
+          Future.successful(Conflict(""))
+        case _ =>
+          aaService.removeFromAssessmentCentreSlot(applicationId).map { _ =>
+            Ok("")
+          }.recover {
+            case _: NotFoundException => NotFound(s"Could not find application assessment for application $applicationId")
+          }
+      }
+    }
+
+  }
+
+  def locationToAssessmentCentreLocation(locationName: String): Action[AnyContent] = Action.async { implicit request =>
+    acRepository.assessmentCentreCapacities.map { assessmentCentres =>
+      assessmentCentres.find(_.locationName == locationName).map { location =>
+        Ok(Json.toJson(LocationName(location.locationName)))
+      }.getOrElse(NotFound("No such location"))
+    }
+  }
+
+  def assessmentCentres: Action[AnyContent] = Action.async { implicit request =>
+    acRepository.assessmentCentreCapacities.map { m =>
+      Ok(Json.toJson(m.flatMap(_.venues.map(_.venueName))))
+    }
+  }
+
+  // TODO Do we need to get un-submitted scores for both assessors and reviewers?
+  def getNonSubmittedScores(assessorId: String): Action[AnyContent] = Action.async { implicit request =>
+    assessmentScoresService.getNonSubmittedCandidateScores(assessorId).map { applicationScores =>
+      Ok(Json.toJson(applicationScores))
+    }
+  }
+  */
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -114,3 +114,6 @@ PUT         /application/:applicationId/issue                            control
 DELETE      /application/:applicationId/issue                            controllers.FlagCandidateController.remove(applicationId: String)
 
 GET         /schools                                                     controllers.SchoolsController.getSchools(term: String)
+
+# Assessment Centres
+GET         /assessment-centre-dates/region/:region                      controllers.AssessmentScheduleController.getAssessmentScheduleDatesByRegion(region: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -353,7 +353,7 @@ scheduling {
       yamlFilePath = assessment-centres-preferred-locations.yaml
     }
     assessment-centres {
-      yamlFilePath = assessment-centres.yaml
+      yamlFilePath = assessment-centres-prod.yaml
     }
   }
   parity-export-job {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -353,7 +353,7 @@ scheduling {
       yamlFilePath = assessment-centres-preferred-locations.yaml
     }
     assessment-centres {
-      yamlFilePath = assessment-centres-prod.yaml
+      yamlFilePath = assessment-centres.yaml
     }
   }
   parity-export-job {

--- a/conf/assessment-centres-prod.yaml
+++ b/conf/assessment-centres-prod.yaml
@@ -2,1188 +2,1187 @@ London:
   - London (Berkeley House):
       description: Berkeley House
       capacities:
-         - date: 24/05/16
+         - date: 24/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/16
+         - date: 26/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/16
+         - date: 31/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/06/16
+         - date: 06/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/16
+         - date: 07/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/16
+         - date: 08/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/16
+         - date: 09/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 1:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/16
+         - date: 05/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/16
+         - date: 06/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/16
+         - date: 09/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/16
+         - date: 10/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/16
+         - date: 12/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 2:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/16
+         - date: 05/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/16
+         - date: 06/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/16
+         - date: 09/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/16
+         - date: 10/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/16
+         - date: 12/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 3:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 4:
       description: FSAC
       capacities:
-         - date: 03/05/16
+         - date: 03/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/16
+         - date: 04/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/16
+         - date: 16/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/16
+         - date: 13/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/16
+         - date: 14/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/16
+         - date: 15/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/16
+         - date: 17/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/16
+         - date: 04/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/16
+         - date: 06/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/16
+         - date: 07/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/16
+         - date: 08/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 5:
       description: FSAC
       capacities:
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/16
+         - date: 28/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
-     
+
 Edinburgh:
   - Edinburgh:
       description: Saughton House
       capacities:
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-     
+
 Bristol:
   - Bristol (Crescent Centre) 2:
       description: The Cresent Centre
       capacities:
-         - date: 09/06/16
+         - date: 09/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/16
+         - date: 15/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/16
+         - date: 22/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
   - Bristol (Learning Centre) 1:
       description: The Cresent Centre
       capacities:
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/16
+         - date: 31/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/16
+         - date: 14/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/16
+         - date: 18/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/16
+         - date: 21/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/16
+         - date: 25/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/16
+         - date: 26/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-     
+
 Manchester:
   - Manchester:
       description: Civil Justice Centre
       capacities:
-         - date: 05/05/16
+         - date: 05/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/16
+         - date: 17/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/05/16
+         - date: 24/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/16
+         - date: 07/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/16
+         - date: 08/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/16
+         - date: 29/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/16
+         - date: 18/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/16
+         - date: 19/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/16
+         - date: 20/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/16
+         - date: 21/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/16
+         - date: 22/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/16
+         - date: 25/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/16
+         - date: 26/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/16
+         - date: 27/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/16
+         - date: 29/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-     
+
 Newcastle:
   - Newcastle Job Centre:
       description: Cathedral Square Jobcentre
       capacities:
-         - date: 18/05/16
+         - date: 18/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/16
+         - date: 19/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/16
+         - date: 20/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/16
+         - date: 28/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/16
+         - date: 29/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
   - Newcastle Longbenton:
       description: Longbenton
       capacities:
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/16
+         - date: 03/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/16
+         - date: 08/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-     
+
 Nottingham:
   - Nottingham (Fitzroy House):
       description: Fitzroy House
       capacities:
-         - date: 31/05/16
+         - date: 31/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/16
+         - date: 01/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/16
+         - date: 02/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/16
+         - date: 04/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/16
+         - date: 05/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/16
+         - date: 08/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
   - Nottingham (The Axis):
       description: The Axis
       capacities:
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/16
+         - date: 28/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/16
+         - date: 29/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/16
+         - date: 30/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/16
+         - date: 01/07/17
            amCapacity: 6
            pmCapacity: 6
-     
+
 Glasgow:
   - Glasgow:
       description: Shettleston Jobcentre
       capacities:
-         - date: 24/05/16
+         - date: 24/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/16
+         - date: 26/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/16
+         - date: 03/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/16
+         - date: 07/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/16
+         - date: 08/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/16
+         - date: 09/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/16
+         - date: 10/06/17
            amCapacity: 6
            pmCapacity: 6
-     
+
 Leeds:
   - Leeds (Quarry House) 1:
       description: Quarry House
       capacities:
-         - date: 10/05/16
+         - date: 10/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/16
+         - date: 11/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/16
+         - date: 12/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/16
+         - date: 13/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/16
+         - date: 25/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/16
+         - date: 26/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/16
+         - date: 27/05/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/16
+         - date: 01/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/16
+         - date: 02/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/06/16
+         - date: 21/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/16
+         - date: 22/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/16
+         - date: 23/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/16
+         - date: 24/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/06/16
+         - date: 27/06/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/16
+         - date: 14/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/16
+         - date: 15/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/16
+         - date: 18/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/16
+         - date: 19/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/16
+         - date: 20/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/16
+         - date: 21/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/16
+         - date: 22/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/16
+         - date: 25/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/16
+         - date: 26/07/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/16
+         - date: 08/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/16
+         - date: 09/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/16
+         - date: 10/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/16
+         - date: 11/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/16
+         - date: 12/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/16
+         - date: 15/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/16
+         - date: 16/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/16
+         - date: 17/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/16
+         - date: 18/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/16
+         - date: 19/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/16
+         - date: 22/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/16
+         - date: 23/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/16
+         - date: 24/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/16
+         - date: 25/08/17
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/16
+         - date: 26/08/17
            amCapacity: 6
            pmCapacity: 6
-     

--- a/conf/assessment-centres.yaml
+++ b/conf/assessment-centres.yaml
@@ -2,1188 +2,1187 @@ London:
   - London (Berkeley House):
       description: Berkeley House
       capacities:
-         - date: 24/05/17
+         - date: 24/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/17
+         - date: 26/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/17
+         - date: 31/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/06/17
+         - date: 06/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/17
+         - date: 07/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/17
+         - date: 08/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/17
+         - date: 09/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 1:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/17
+         - date: 05/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/17
+         - date: 06/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/17
+         - date: 09/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/17
+         - date: 10/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/17
+         - date: 12/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 2:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/05/17
+         - date: 05/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/05/17
+         - date: 06/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/05/17
+         - date: 09/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/05/17
+         - date: 10/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/17
+         - date: 12/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 3:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 4:
       description: FSAC
       capacities:
-         - date: 03/05/17
+         - date: 03/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/05/17
+         - date: 04/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/05/17
+         - date: 16/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/06/17
+         - date: 13/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/06/17
+         - date: 14/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/06/17
+         - date: 15/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/06/17
+         - date: 17/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/07/17
+         - date: 04/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 06/07/17
+         - date: 06/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/07/17
+         - date: 07/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/07/17
+         - date: 08/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
   - London (FSAC) 5:
       description: FSAC
       capacities:
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/07/17
+         - date: 28/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
-     
+
 Edinburgh:
   - Edinburgh:
       description: Saughton House
       capacities:
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-     
+
 Bristol:
   - Bristol (Crescent Centre) 2:
       description: The Cresent Centre
       capacities:
-         - date: 09/06/17
+         - date: 09/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/17
+         - date: 15/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/17
+         - date: 22/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
   - Bristol (Learning Centre) 1:
       description: The Cresent Centre
       capacities:
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 31/05/17
+         - date: 31/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/17
+         - date: 14/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/17
+         - date: 18/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/17
+         - date: 21/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/17
+         - date: 25/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/17
+         - date: 26/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-     
+
 Manchester:
   - Manchester:
       description: Civil Justice Centre
       capacities:
-         - date: 05/05/17
+         - date: 05/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/05/17
+         - date: 17/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/05/17
+         - date: 24/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/17
+         - date: 07/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/17
+         - date: 08/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/17
+         - date: 29/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/17
+         - date: 18/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/17
+         - date: 19/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/17
+         - date: 20/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/17
+         - date: 21/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/17
+         - date: 22/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/17
+         - date: 25/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/17
+         - date: 26/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/07/17
+         - date: 27/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/07/17
+         - date: 29/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-     
+
 Newcastle:
   - Newcastle Job Centre:
       description: Cathedral Square Jobcentre
       capacities:
-         - date: 18/05/17
+         - date: 18/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/05/17
+         - date: 19/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/05/17
+         - date: 20/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/17
+         - date: 28/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/17
+         - date: 29/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
   - Newcastle Longbenton:
       description: Longbenton
       capacities:
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/08/17
+         - date: 03/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/17
+         - date: 08/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-     
+
 Nottingham:
   - Nottingham (Fitzroy House):
       description: Fitzroy House
       capacities:
-         - date: 31/05/17
+         - date: 31/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/08/17
+         - date: 01/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/08/17
+         - date: 02/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 04/08/17
+         - date: 04/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 05/08/17
+         - date: 05/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/17
+         - date: 08/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
   - Nottingham (The Axis):
       description: The Axis
       capacities:
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 28/06/17
+         - date: 28/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 29/06/17
+         - date: 29/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 30/06/17
+         - date: 30/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/07/17
+         - date: 01/07/18
            amCapacity: 6
            pmCapacity: 6
-     
+
 Glasgow:
   - Glasgow:
       description: Shettleston Jobcentre
       capacities:
-         - date: 24/05/17
+         - date: 24/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/17
+         - date: 26/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 03/06/17
+         - date: 03/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 07/06/17
+         - date: 07/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/06/17
+         - date: 08/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/06/17
+         - date: 09/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/06/17
+         - date: 10/06/18
            amCapacity: 6
            pmCapacity: 6
-     
+
 Leeds:
   - Leeds (Quarry House) 1:
       description: Quarry House
       capacities:
-         - date: 10/05/17
+         - date: 10/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/05/17
+         - date: 11/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/05/17
+         - date: 12/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 13/05/17
+         - date: 13/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/05/17
+         - date: 25/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/05/17
+         - date: 26/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/05/17
+         - date: 27/05/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 01/06/17
+         - date: 01/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 02/06/17
+         - date: 02/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/06/17
+         - date: 21/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/06/17
+         - date: 22/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/06/17
+         - date: 23/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/06/17
+         - date: 24/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 27/06/17
+         - date: 27/06/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 14/07/17
+         - date: 14/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/07/17
+         - date: 15/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/07/17
+         - date: 18/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/07/17
+         - date: 19/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 20/07/17
+         - date: 20/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 21/07/17
+         - date: 21/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/07/17
+         - date: 22/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/07/17
+         - date: 25/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/07/17
+         - date: 26/07/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 08/08/17
+         - date: 08/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 09/08/17
+         - date: 09/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 10/08/17
+         - date: 10/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 11/08/17
+         - date: 11/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 12/08/17
+         - date: 12/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 15/08/17
+         - date: 15/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 16/08/17
+         - date: 16/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 17/08/17
+         - date: 17/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 18/08/17
+         - date: 18/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 19/08/17
+         - date: 19/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 22/08/17
+         - date: 22/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 23/08/17
+         - date: 23/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 24/08/17
+         - date: 24/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 25/08/17
+         - date: 25/08/18
            amCapacity: 6
            pmCapacity: 6
-         - date: 26/08/17
+         - date: 26/08/18
            amCapacity: 6
            pmCapacity: 6
-     

--- a/it/repositories/AssessmentCentreYamlRepositorySpec.scala
+++ b/it/repositories/AssessmentCentreYamlRepositorySpec.scala
@@ -67,7 +67,7 @@ class AssessmentCentreYamlRepositorySpec extends UnitWithAppSpec {
       val capacityDate = venue.capacityDates.head
       capacityDate.amCapacity mustBe 6
       capacityDate.pmCapacity mustBe 6
-      capacityDate.date.toString(DateFormat) mustBe "24/5/17"
+      capacityDate.date.toString(DateFormat) mustBe "24/5/18"
     }
 
     "reject invalid configuration" in {
@@ -118,7 +118,7 @@ class AssessmentCentreYamlRepositorySpec extends UnitWithAppSpec {
       val venue = assessmentCapacity.venues(1)
       venue.venueName mustBe "London (FSAC) 1"
       venue.venueDescription mustBe "FSAC"
-      val capacityDate = venue.capacityDates.find(_.date == new LocalDate("2016-07-04")).get
+      val capacityDate = venue.capacityDates.find(_.date == new LocalDate("2017-07-04")).get
       capacityDate.amCapacity mustBe 6
       capacityDate.pmCapacity mustBe 6
     }


### PR DESCRIPTION
- Resurrect the assessmentschedulecontroller but comment out lots of old methods. They will likely all be needed again soon, which is the reason i've not gone for a delete.
- Create a new endpoint to 'getAssessmentScheduleDatesByRegion'