### PR TITLE
Generate a smattering of other roles when the database is cleared, to speed QA

### DIFF
--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -43,7 +43,23 @@ trait TestDataGeneratorService extends MongoDbConnection {
       _ <- AuthProviderClient.removeAllUsers()
       _ <- RegisteredStatusGenerator.createUser(
         1,
-        "test_service_manager_1@mailinator.com", "CSR Test", "Service Manager", Some("TestServiceManager"), AuthProviderClient.TechnicalAdminRole
+        "test_service_manager_1@mailinator.com", "CSR Test", "Tech Admin", Some("TestServiceManager"), AuthProviderClient.TechnicalAdminRole
+      )
+      _ <- RegisteredStatusGenerator.createUser(
+        1,
+        "test_techadmin@mailinator.com", "CSR Test", "Tech Admin", Some("TestServiceManager"), AuthProviderClient.TechnicalAdminRole
+      )
+      _ <- RegisteredStatusGenerator.createUser(
+        1,
+        "test_service_admin@mailinator.com", "CSR Test", "Service Admin", Some("TestServiceManager"), AuthProviderClient.ServiceAdminRole
+      )
+      _ <- RegisteredStatusGenerator.createUser(
+        1,
+        "test_assessor@mailinator.com", "CSR Test", "Assessor", Some("TestServiceManager"), AuthProviderClient.AssessorRole
+      )
+      _ <- RegisteredStatusGenerator.createUser(
+        1,
+        "test_qac@mailinator.com", "CSR Test", "QAC", Some("TestServiceManager"), AuthProviderClient.QacRole
       )
     } yield {
       ()


### PR DESCRIPTION
In our QA environments this will add users with logins:

test_service_manager_1@mailinator.com (retained for legacy support, please try and use the new ones from now on)

test_techadmin@mailinator.com
test_service_admin@mailinator.com
test_assessor@mailinator.com
test_qac@mailinator.com