### PR TITLE
FSET-1542: Provide flag for turning off test assessor generation

### DIFF
--- a/app/controllers/testdata/TestDataGeneratorController.scala
+++ b/app/controllers/testdata/TestDataGeneratorController.scala
@@ -46,8 +46,8 @@ trait TestDataGeneratorController extends BaseController {
     Ok("OK")
   }
 
-  def clearDatabase(generateDefaultRoles: Boolean) = Action.async { implicit request =>
-    TestDataGeneratorService.clearDatabase(generateDefaultRoles).map { _ =>
+  def clearDatabase(generateDefaultUsers: Boolean) = Action.async { implicit request =>
+    TestDataGeneratorService.clearDatabase(generateDefaultUsers).map { _ =>
       Ok(Json.parse("""{"message": "success"}"""))
     }
   }

--- a/app/controllers/testdata/TestDataGeneratorController.scala
+++ b/app/controllers/testdata/TestDataGeneratorController.scala
@@ -46,8 +46,8 @@ trait TestDataGeneratorController extends BaseController {
     Ok("OK")
   }
 
-  def clearDatabase() = Action.async { implicit request =>
-    TestDataGeneratorService.clearDatabase().map { _ =>
+  def clearDatabase(generateDefaultAssessor: Boolean) = Action.async { implicit request =>
+    TestDataGeneratorService.clearDatabase(generateDefaultAssessor).map { _ =>
       Ok(Json.parse("""{"message": "success"}"""))
     }
   }

--- a/app/controllers/testdata/TestDataGeneratorController.scala
+++ b/app/controllers/testdata/TestDataGeneratorController.scala
@@ -46,8 +46,8 @@ trait TestDataGeneratorController extends BaseController {
     Ok("OK")
   }
 
-  def clearDatabase(generateDefaultAssessor: Boolean) = Action.async { implicit request =>
-    TestDataGeneratorService.clearDatabase(generateDefaultAssessor).map { _ =>
+  def clearDatabase(generateDefaultRoles: Boolean) = Action.async { implicit request =>
+    TestDataGeneratorService.clearDatabase(generateDefaultRoles).map { _ =>
       Ok(Json.parse("""{"message": "success"}"""))
     }
   }

--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -42,9 +42,7 @@ trait TestDataGeneratorService extends MongoDbConnection {
       _ <- db().drop()
       _ <- AuthProviderClient.removeAllUsers()
       _ <- generateUsers() if generateDefaultUsers
-    } yield {
-      ()
-    }
+    } yield ()
   }
 
   def generateUsers()(implicit hc: HeaderCarrier): Future[Unit] = {

--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -37,7 +37,7 @@ object TestDataGeneratorService extends TestDataGeneratorService {
 
 trait TestDataGeneratorService extends MongoDbConnection {
 
-  def clearDatabase()(implicit hc: HeaderCarrier): Future[Unit] = {
+  def clearDatabase(generateDefaultAssessor: Boolean)(implicit hc: HeaderCarrier): Future[Unit] = {
     for {
       _ <- db().drop()
       _ <- AuthProviderClient.removeAllUsers()
@@ -56,7 +56,7 @@ trait TestDataGeneratorService extends MongoDbConnection {
       _ <- RegisteredStatusGenerator.createUser(
         1,
         "test_assessor@mailinator.com", "CSR Test", "Assessor", Some("TestServiceManager"), AuthProviderClient.AssessorRole
-      )
+      ) if generateDefaultAssessor
       _ <- RegisteredStatusGenerator.createUser(
         1,
         "test_qac@mailinator.com", "CSR Test", "QAC", Some("TestServiceManager"), AuthProviderClient.QacRole

--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -37,17 +37,17 @@ object TestDataGeneratorService extends TestDataGeneratorService {
 
 trait TestDataGeneratorService extends MongoDbConnection {
 
-  def clearDatabase(generateDefaultRoles: Boolean)(implicit hc: HeaderCarrier): Future[Unit] = {
+  def clearDatabase(generateDefaultUsers: Boolean)(implicit hc: HeaderCarrier): Future[Unit] = {
     for {
       _ <- db().drop()
       _ <- AuthProviderClient.removeAllUsers()
-      _ <- generateRoles() if generateDefaultRoles
+      _ <- generateUsers() if generateDefaultUsers
     } yield {
       ()
     }
   }
 
-  def generateRoles()(implicit hc: HeaderCarrier): Future[Unit] = {
+  def generateUsers()(implicit hc: HeaderCarrier): Future[Unit] = {
     for {
       _ <- RegisteredStatusGenerator.createUser(
         1,

--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -37,10 +37,18 @@ object TestDataGeneratorService extends TestDataGeneratorService {
 
 trait TestDataGeneratorService extends MongoDbConnection {
 
-  def clearDatabase(generateDefaultAssessor: Boolean)(implicit hc: HeaderCarrier): Future[Unit] = {
+  def clearDatabase(generateDefaultRoles: Boolean)(implicit hc: HeaderCarrier): Future[Unit] = {
     for {
       _ <- db().drop()
       _ <- AuthProviderClient.removeAllUsers()
+      _ <- generateRoles() if generateDefaultRoles
+    } yield {
+      ()
+    }
+  }
+
+  def generateRoles()(implicit hc: HeaderCarrier): Future[Unit] = {
+    for {
       _ <- RegisteredStatusGenerator.createUser(
         1,
         "test_service_manager_1@mailinator.com", "CSR Test", "Tech Admin", Some("TestServiceManager"), AuthProviderClient.TechnicalAdminRole
@@ -56,14 +64,12 @@ trait TestDataGeneratorService extends MongoDbConnection {
       _ <- RegisteredStatusGenerator.createUser(
         1,
         "test_assessor@mailinator.com", "CSR Test", "Assessor", Some("TestServiceManager"), AuthProviderClient.AssessorRole
-      ) if generateDefaultAssessor
+      )
       _ <- RegisteredStatusGenerator.createUser(
         1,
         "test_qac@mailinator.com", "CSR Test", "QAC", Some("TestServiceManager"), AuthProviderClient.QacRole
       )
-    } yield {
-      ()
-    }
+    } yield { () }
   }
 
   def createAdminUsers(numberToGenerate: Int, emailPrefix: Option[String],

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -13,7 +13,7 @@
 ->         /                          prod.Routes
 
 GET     /candidate-application/test-data-generator/ping                     controllers.testdata.TestDataGeneratorController.ping
-GET     /candidate-application/test-data-generator/clear-database           controllers.testdata.TestDataGeneratorController.clearDatabase(generateDefaultAssessor: Boolean ?= true)
+GET     /candidate-application/test-data-generator/clear-database           controllers.testdata.TestDataGeneratorController.clearDatabase(generateDefaultRoles: Boolean ?= true)
 GET     /candidate-application/test-data-generator/create-admin-users       controllers.testdata.TestDataGeneratorController.createAdminUsers(numberToGenerate: Int, emailPrefix: Option[String] ?= None, role: String ?= "tech-admin")
 POST    /candidate-application/test-data-generator/create-candidates        controllers.testdata.TestDataGeneratorController.createCandidatesInStatusPOST(numberToGenerate: Int)
 GET     /candidate-application/test-data-generator/example                  controllers.testdata.TestDataGeneratorController.requestExample

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -13,7 +13,7 @@
 ->         /                          prod.Routes
 
 GET     /candidate-application/test-data-generator/ping                     controllers.testdata.TestDataGeneratorController.ping
-GET     /candidate-application/test-data-generator/clear-database           controllers.testdata.TestDataGeneratorController.clearDatabase(generateDefaultRoles: Boolean ?= true)
+GET     /candidate-application/test-data-generator/clear-database           controllers.testdata.TestDataGeneratorController.clearDatabase(generateDefaultUsers: Boolean ?= true)
 GET     /candidate-application/test-data-generator/create-admin-users       controllers.testdata.TestDataGeneratorController.createAdminUsers(numberToGenerate: Int, emailPrefix: Option[String] ?= None, role: String ?= "tech-admin")
 POST    /candidate-application/test-data-generator/create-candidates        controllers.testdata.TestDataGeneratorController.createCandidatesInStatusPOST(numberToGenerate: Int)
 GET     /candidate-application/test-data-generator/example                  controllers.testdata.TestDataGeneratorController.requestExample

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -13,7 +13,7 @@
 ->         /                          prod.Routes
 
 GET     /candidate-application/test-data-generator/ping                     controllers.testdata.TestDataGeneratorController.ping
-GET     /candidate-application/test-data-generator/clear-database           controllers.testdata.TestDataGeneratorController.clearDatabase()
+GET     /candidate-application/test-data-generator/clear-database           controllers.testdata.TestDataGeneratorController.clearDatabase(generateDefaultAssessor: Boolean ?= true)
 GET     /candidate-application/test-data-generator/create-admin-users       controllers.testdata.TestDataGeneratorController.createAdminUsers(numberToGenerate: Int, emailPrefix: Option[String] ?= None, role: String ?= "tech-admin")
 POST    /candidate-application/test-data-generator/create-candidates        controllers.testdata.TestDataGeneratorController.createCandidatesInStatusPOST(numberToGenerate: Int)
 GET     /candidate-application/test-data-generator/example                  controllers.testdata.TestDataGeneratorController.requestExample


### PR DESCRIPTION
This is an initial stab at making the user generation dynamic. At the moment, I've used a flag for this `?generateDefaultAssessor=false`. I won't be surprised if we will want to add the same flag for the other types of roles. 

I can either make the others dynamic too via query params OR we provide a flag to turn them all on/off OR we just do for the one flag(assessors) and add for others as the need arises.

Thoughts?

_p.s I'm making this change because it is required for a test in FSET-1542_