### PR TITLE
Update TDG to save generate passmark evaluation for previous phases if

### DIFF
--- a/app/connectors/testdata/ExchangeObjects.scala
+++ b/app/connectors/testdata/ExchangeObjects.scala
@@ -17,11 +17,11 @@
 package connectors.testdata
 
 import model.Commands.ApplicationAssessment
-import model.persisted.{ AssistanceDetails, ContactDetails }
+import model.persisted.AssistanceDetails
 import model.command.GeneralDetails
 import model.persisted._
-import model.{ Adjustments, CivilServiceExperienceDetails, SelectedSchemes }
-import play.api.libs.json.Json
+import model.{ Adjustments, SelectedSchemes }
+import play.api.libs.json.{ Json, OFormat }
 
 object ExchangeObjects {
 
@@ -45,16 +45,14 @@ object ExchangeObjects {
                                      adjustmentInformation: Option[Adjustments] = None
   )
 
-  case class TestGroupResponse(tests: List[TestResponse])
+  object DataGenerationResponse {
+    implicit val dataGenerationResponseFormat: OFormat[DataGenerationResponse] = Json.format[DataGenerationResponse]
+  }
+
+  case class TestGroupResponse(tests: List[TestResponse], schemeResult: Option[PassmarkEvaluation])
+  object TestGroupResponse { implicit val testGroupResponseFormat: OFormat[TestGroupResponse] = Json.format[TestGroupResponse] }
 
   case class TestResponse(testId: Int, testType: String, token: String, testUrl: String)
+  object TestResponse { implicit val testResponseFormat: OFormat[TestResponse] = Json.format[TestResponse] }
 
-
-  object Implicits {
-
-    import model.Commands.Implicits._
-    implicit val testResponseFormat = Json.format[TestResponse]
-    implicit val testGroupResponseFormat = Json.format[TestGroupResponse]
-    implicit val dataGenerationResponseFormat = Json.format[DataGenerationResponse]
-  }
 }

--- a/app/controllers/AssessmentScheduleController.scala
+++ b/app/controllers/AssessmentScheduleController.scala
@@ -26,7 +26,6 @@ import connectors.ExchangeObjects.AllocationDetails
 import connectors.{ CSREmailClient, EmailClient }
 import model.AssessmentScheduleCommands.ApplicationForAssessmentAllocationResult
 import model.AssessmentScheduleCommands.Implicits.ApplicationForAssessmentAllocationResultFormats
-import model.Commands.Implicits.applicationAssessmentFormat
 import model.Exceptions.NotFoundException
 import model.command.AssessmentCentreAllocation
 import model.{ Commands, ProgressStatuses }

--- a/app/controllers/testdata/TestDataGeneratorController.scala
+++ b/app/controllers/testdata/TestDataGeneratorController.scala
@@ -21,7 +21,6 @@ import java.io.File
 import com.typesafe.config.ConfigFactory
 import config.MicroserviceAppConfig
 import connectors.AuthProviderClient
-import connectors.testdata.ExchangeObjects.Implicits._
 import model.Exceptions.EmailTakenException
 import model.command.testdata.GeneratorConfig
 import model.exchange.testdata._

--- a/app/model/Commands.scala
+++ b/app/model/Commands.scala
@@ -176,11 +176,11 @@ object Commands {
                        preferredName: Option[String], dateOfBirth: Option[LocalDate], address: Option[Address], postCode: Option[PostCode],
                        country: Option[String], applicationRoute: Option[ApplicationRoute], applicationStatus: Option[String]) {
 
-    def name = preferredName.getOrElse(firstName.getOrElse(""))
+    def name: String = preferredName.getOrElse(firstName.getOrElse(""))
   }
 
   case class ApplicationAssessment(applicationId: String, venue: String, date: LocalDate, session: String, slot: Int, confirmed: Boolean) {
-    val assessmentDateTime = {
+    val assessmentDateTime: DateTime = {
       // TODO This should be configurable in the future, but hardcoding it in the fasttrack service is the lesser of the evils at the moment
       // FSET-471 was an emergency last minute fix
       if (venue == "Manchester" || venue == "London (Berkeley House)") {
@@ -208,56 +208,57 @@ object Commands {
     def expireDate: LocalDate = date.minusDays(11)
   }
 
+  object ApplicationAssessment { implicit val applicationAssessmentFormat: OFormat[ApplicationAssessment] = Json.format[ApplicationAssessment] }
+
   case class AssessmentCentrePassMarkSettingsResponse(
                                                        schemes: List[AssessmentCentrePassMarkScheme],
                                                        info: Option[AssessmentCentrePassMarkInfo]
                                                      )
 
   object Implicits {
-    implicit val addressFormat = Json.format[Address]
-    implicit val applicationAddedFormat = Json.format[ApplicationResponse]
-    implicit val passMarkSettingsCreateResponseFormat = Json.format[PassMarkSettingsCreateResponse]
-    implicit val personalDetailsAddedFormat = Json.format[PersonalDetailsAdded]
+    implicit val addressFormat: OFormat[Address] = Json.format[Address]
+    implicit val applicationAddedFormat: OFormat[ApplicationResponse] = Json.format[ApplicationResponse]
+    implicit val passMarkSettingsCreateResponseFormat: OFormat[PassMarkSettingsCreateResponse] = Json.format[PassMarkSettingsCreateResponse]
+    implicit val personalDetailsAddedFormat: OFormat[PersonalDetailsAdded] = Json.format[PersonalDetailsAdded]
     implicit val createApplicationRequestFormat: Format[CreateApplicationRequest] = Json.format[CreateApplicationRequest]
 
-    implicit val answerFormat = Json.format[Answer]
-    implicit val questionFormat = Json.format[Question]
-    implicit val questionnaireFormat = Json.format[Questionnaire]
-    implicit val previewFormat = Json.format[PreviewRequest]
+    implicit val answerFormat: OFormat[Answer] = Json.format[Answer]
+    implicit val questionFormat: OFormat[Question] = Json.format[Question]
+    implicit val questionnaireFormat: OFormat[Questionnaire] = Json.format[Questionnaire]
+    implicit val previewFormat: OFormat[PreviewRequest] = Json.format[PreviewRequest]
 
-    implicit val submissionDeadlineFormat = Json.format[OverrideSubmissionDeadlineRequest]
+    implicit val submissionDeadlineFormat: OFormat[OverrideSubmissionDeadlineRequest] = Json.format[OverrideSubmissionDeadlineRequest]
 
-    implicit val tooManyEntriesFormat = Json.format[TooManyEntries]
-    implicit val noResultsReturnedFormat = Json.format[NoResultsReturned]
+    implicit val tooManyEntriesFormat: OFormat[TooManyEntries] = Json.format[TooManyEntries]
+    implicit val noResultsReturnedFormat: OFormat[NoResultsReturned] = Json.format[NoResultsReturned]
 
-    implicit val searchCandidateFormat = Json.format[SearchCandidate]
-    implicit val candidateFormat = Json.format[Candidate]
-    implicit val reportFormat = Json.format[Report]
-    implicit val preferencesWithContactDetailsFormat = Json.format[PreferencesWithContactDetails]
+    implicit val searchCandidateFormat: OFormat[SearchCandidate] = Json.format[SearchCandidate]
+    implicit val candidateFormat: OFormat[Candidate] = Json.format[Candidate]
+    implicit val reportFormat: OFormat[Report] = Json.format[Report]
+    implicit val preferencesWithContactDetailsFormat: OFormat[PreferencesWithContactDetails] = Json.format[PreferencesWithContactDetails]
 
     implicit def fromCommandToPersistedQuestion(q: Question): QuestionnaireQuestion =
       QuestionnaireQuestion(q.question, QuestionnaireAnswer(q.answer.answer, q.answer.otherDetails, q.answer.unknown))
 
-    implicit val onlineTestDetailsFormat = Json.format[OnlineTestDetails]
-    implicit val onlineTestFormat = Json.format[OnlineTest]
-    implicit val onlineTestStatusFormat = Json.format[OnlineTestStatus]
-    implicit val userIdWrapperFormat = Json.format[UserIdWrapper]
+    implicit val onlineTestDetailsFormat: OFormat[OnlineTestDetails] = Json.format[OnlineTestDetails]
+    implicit val onlineTestFormat: OFormat[OnlineTest] = Json.format[OnlineTest]
+    implicit val onlineTestStatusFormat: OFormat[OnlineTestStatus] = Json.format[OnlineTestStatus]
+    implicit val userIdWrapperFormat: OFormat[UserIdWrapper] = Json.format[UserIdWrapper]
 
-    implicit val assessmentCentreAllocationReportFormat = Json.format[AssessmentCentreAllocationReport]
-    implicit val candidateAwaitingAllocationFormat = Json.format[CandidateAwaitingAllocation]
+    implicit val assessmentCentreAllocationReportFormat: OFormat[AssessmentCentreAllocationReport] = Json.format[AssessmentCentreAllocationReport]
+    implicit val candidateAwaitingAllocationFormat: OFormat[CandidateAwaitingAllocation] = Json.format[CandidateAwaitingAllocation]
 
-    implicit val applicationAssessmentFormat = Json.format[ApplicationAssessment]
-    implicit val phoneAndEmailFormat = Json.format[PhoneAndEmail]
-    implicit val reportWithPersonalDetailsFormat = Json.format[ReportWithPersonalDetails]
-    implicit val assessmentCentrePassMarkSettingsResponseFormat = Json.format[AssessmentCentrePassMarkSettingsResponse]
-    implicit val passMarkEvaluationSchemes = Json.format[OnlineTestPassmarkEvaluationSchemes]
-    implicit val applicationPreferencesFormat = Json.format[ApplicationPreferences]
-    implicit val assessmentResultsReportFormat = Json.format[AssessmentResultsReport]
-    implicit val personalInfoFormat = Json.format[PersonalInfo]
-    implicit val schemeEvaluationFormat = Json.format[SchemeEvaluation]
-    implicit val candidateScoresSummaryFormat = Json.format[CandidateScoresSummary]
-    implicit val applicationPreferencesWithTestResultsFormat = Json.format[ApplicationPreferencesWithTestResults]
-    implicit val assessmentCentreCandidatesReportFormat = Json.format[AssessmentCentreCandidatesReport]
+    implicit val phoneAndEmailFormat: OFormat[PhoneAndEmail] = Json.format[PhoneAndEmail]
+    implicit val reportWithPersonalDetailsFormat: OFormat[ReportWithPersonalDetails] = Json.format[ReportWithPersonalDetails]
+    implicit val assessmentCentrePassMarkSettingsResponseFormat: OFormat[AssessmentCentrePassMarkSettingsResponse] = Json.format[AssessmentCentrePassMarkSettingsResponse]
+    implicit val passMarkEvaluationSchemes: OFormat[OnlineTestPassmarkEvaluationSchemes] = Json.format[OnlineTestPassmarkEvaluationSchemes]
+    implicit val applicationPreferencesFormat: OFormat[ApplicationPreferences] = Json.format[ApplicationPreferences]
+    implicit val assessmentResultsReportFormat: OFormat[AssessmentResultsReport] = Json.format[AssessmentResultsReport]
+    implicit val personalInfoFormat: OFormat[PersonalInfo] = Json.format[PersonalInfo]
+    implicit val schemeEvaluationFormat: OFormat[SchemeEvaluation] = Json.format[SchemeEvaluation]
+    implicit val candidateScoresSummaryFormat: OFormat[CandidateScoresSummary] = Json.format[CandidateScoresSummary]
+    implicit val applicationPreferencesWithTestResultsFormat: OFormat[ApplicationPreferencesWithTestResults] = Json.format[ApplicationPreferencesWithTestResults]
+    implicit val assessmentCentreCandidatesReportFormat: OFormat[AssessmentCentreCandidatesReport] = Json.format[AssessmentCentreCandidatesReport]
   }
 
 }

--- a/app/repositories/ApplicationAssessmentRepository.scala
+++ b/app/repositories/ApplicationAssessmentRepository.scala
@@ -41,7 +41,7 @@ trait ApplicationAssessmentRepository {
 
 class ApplicationAssessmentMongoRepository()(implicit mongo: () => DB)
   extends ReactiveRepository[ApplicationAssessment, BSONObjectID](CollectionNames.APPLICATION_ASSESSMENT, mongo,
-    Commands.Implicits.applicationAssessmentFormat, ReactiveMongoFormats.objectIdFormats) with
+    Commands.ApplicationAssessment.applicationAssessmentFormat, ReactiveMongoFormats.objectIdFormats) with
     ApplicationAssessmentRepository with ReactiveRepositoryHelpers {
 
   def find(applicationId: String): Future[ApplicationAssessment] = {

--- a/app/services/onlinetesting/phase3/Phase3TestEvaluation.scala
+++ b/app/services/onlinetesting/phase3/Phase3TestEvaluation.scala
@@ -30,6 +30,7 @@ trait Phase3TestEvaluation extends OnlineTestResultsCalculator {
   def evaluate(schemes: List[SchemeType], launchpadTestResult: ReviewedCallbackRequest,
                phase2SchemesEvaluation: List[SchemeEvaluationResult],
                passmark: Phase3PassMarkSettings): List[SchemeEvaluationResult] = {
+
     for {
       schemeToEvaluate <- schemes
       schemePassmark <- passmark.schemes find (_.schemeName == schemeToEvaluate)

--- a/app/services/testdata/onlinetests/phase1/Phase1TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/onlinetests/phase1/Phase1TestsInvitedStatusGenerator.scala
@@ -81,7 +81,8 @@ trait Phase1TestsInvitedStatusGenerator extends ConstructiveGenerator {
           List(TestResponse(sjq.cubiksUserId, "sjq", sjq.token, sjq.testUrl)) ++
           bq.map { b =>
             List(TestResponse(b.cubiksUserId, "bq", b.token, b.testUrl))
-          }.getOrElse(Nil)
+          }.getOrElse(Nil),
+          None
         )
       ))
     }

--- a/app/services/testdata/onlinetests/phase2/Phase2TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/onlinetests/phase2/Phase2TestsInvitedStatusGenerator.scala
@@ -76,7 +76,7 @@ trait Phase2TestsInvitedStatusGenerator extends ConstructiveGenerator {
       val etray = phase2TestGroup.tests.head
 
       candidateInPreviousStatus.copy(
-        phase2TestGroup = Some(TestGroupResponse(List(TestResponse(etray.cubiksUserId, "etray", etray.token, etray.testUrl)))),
+        phase2TestGroup = Some(TestGroupResponse(List(TestResponse(etray.cubiksUserId, "etray", etray.token, etray.testUrl)), None)),
         accessCode = etray.invigilatedAccessCode
       )
     }

--- a/app/services/testdata/onlinetests/phase3/Phase3TestsInvitedStatusGenerator.scala
+++ b/app/services/testdata/onlinetests/phase3/Phase3TestsInvitedStatusGenerator.scala
@@ -92,7 +92,7 @@ trait Phase3TestsInvitedStatusGenerator extends ConstructiveGenerator {
         testUrl = testGroup.get.tests.find(_.usedForResults).get.testUrl)
 
       candidateInPreviousStatus.copy(
-        phase3TestGroup = Some(TestGroupResponse(List(phase3TestGroupResponse)))
+        phase3TestGroup = Some(TestGroupResponse(List(phase3TestGroupResponse), None))
       )
     }
   }


### PR DESCRIPTION
not specified in generation request.
Tidy up some implicit formats.