### PR TITLE
Refactor skill path parameters in ApplicationClient

### DIFF
--- a/app/controllers/DayAggregateEventController.scala
+++ b/app/controllers/DayAggregateEventController.scala
@@ -17,10 +17,11 @@
 package controllers
 
 import model.persisted.eventschedules.Location
+import model.persisted.eventschedules.SkillType.SkillType
 import org.joda.time.LocalDate
-import play.api.libs.json.{Json, OFormat}
-import play.api.mvc.{Action, AnyContent}
-import repositories.events.{ EventsRepository, LocationsWithVenuesRepository, LocationsWithVenuesInMemoryRepository }
+import play.api.libs.json.{ Json, OFormat }
+import play.api.mvc.{ Action, AnyContent }
+import repositories.events.{ EventsRepository, LocationsWithVenuesInMemoryRepository, LocationsWithVenuesRepository }
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -35,20 +36,18 @@ trait DayAggregateEventController extends BaseController {
   def locationsWithVenuesRepo: LocationsWithVenuesRepository
   def eventsRepository: EventsRepository
 
-  def findBySkillTypes(skillTypes: String): Action[AnyContent] = Action.async { implicit request =>
-    find(Some(skillTypes), None).map ( dayAggregateEvents => Ok(Json.toJson(dayAggregateEvents)) )
+  def findBySkillTypes(skills: List[SkillType]): Action[AnyContent] = Action.async { implicit request =>
+    find(None, skills).map ( dayAggregateEvents => Ok(Json.toJson(dayAggregateEvents)) )
   }
 
-  def findBySkillTypesAndLocation(skillTypes: String, location: String): Action[AnyContent] = Action.async { implicit request =>
+  def findBySkillTypesAndLocation(location: String, skills: List[SkillType] ): Action[AnyContent] = Action.async { implicit request =>
     locationsWithVenuesRepo.location(location).flatMap { location =>
-      find(Some(skillTypes), Some(location))
+      find(Some(location), skills)
     }.map(dayAggregateEvents => Ok(Json.toJson(dayAggregateEvents)))
   }
 
-  private def find(skillTypes: Option[String], location: Option[Location]) = {
-    val skillTypesList = skillTypes.map(_.split(",").toList)
-
-    eventsRepository.getEvents(None, None, location, skillTypesList).map {
+  private def find(location: Option[Location] = None, skills: List[SkillType] = Nil) = {
+    eventsRepository.getEvents(None, None, location, skills).map {
       _.groupBy(e => DayAggregateEvent(e.date, e.location)).keys.toList
     }
   }

--- a/app/repositories/events/EventsRepository.scala
+++ b/app/repositories/events/EventsRepository.scala
@@ -18,10 +18,11 @@ package repositories.events
 
 import config.MicroserviceAppConfig
 import model.Exceptions.EventNotFoundException
-import model.persisted.eventschedules.{Event, EventType, Location, Venue}
+import model.persisted.eventschedules.{ Event, EventType, Location, Venue }
 import model.persisted.eventschedules.EventType.EventType
+import model.persisted.eventschedules.SkillType.SkillType
 import reactivemongo.api.DB
-import reactivemongo.bson.{BSONArray, BSONDocument, BSONObjectID}
+import reactivemongo.bson.{ BSONArray, BSONDocument, BSONObjectID }
 import repositories.CollectionNames
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
@@ -33,7 +34,7 @@ trait EventsRepository {
   def save(events: List[Event]): Future[Unit]
   def getEvent(id: String): Future[Event]
   def getEvents(eventType: Option[EventType] = None, venue: Option[Venue] = None,
-    location: Option[Location] = None, skills: Option[List[String]] = None): Future[List[Event]]
+    location: Option[Location] = None, skills: List[SkillType] = Nil): Future[List[Event]]
 }
 
 class EventsMongoRepository(implicit mongo: () => DB)
@@ -54,18 +55,20 @@ class EventsMongoRepository(implicit mongo: () => DB)
   }
 
   def getEvents(eventType: Option[EventType] = None, venueType: Option[Venue] = None,
-    location: Option[Location] = None, skills: Option[List[String]] = None
+    location: Option[Location] = None, skills: List[SkillType] = Nil
   ): Future[List[Event]] = {
     val query = List(
       eventType.filterNot(_ == EventType.ALL_EVENTS).map { eventTypeVal => BSONDocument("eventType" -> eventTypeVal.toString) },
       venueType.filterNot(_ == MicroserviceAppConfig.AllVenues).map { v => BSONDocument("venue" -> v) },
       location.map { locationVal => BSONDocument("location" -> locationVal) },
-      skills.map { skillsVal =>
-        val skillsPartialQueries = skillsVal.map { skillVal =>
-          s"skillRequirements.$skillVal" -> BSONDocument("$gte" -> 1)
-        }
-        BSONDocument("$or" -> BSONArray.apply(skillsPartialQueries.map(BSONDocument(_))))
-      }
+
+      if (skills.nonEmpty) {
+        Some(BSONDocument("$or" -> BSONArray(
+          skills.map { skill =>
+            BSONDocument(s"skillRequirements.$skill" -> BSONDocument("$gte" -> 1))
+        })))
+      } else { None }
+
     ).flatten.fold(BSONDocument.empty)(_ ++ _)
 
     collection.find(query).cursor[Event]().collect[List]()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -127,8 +127,8 @@ GET         /events/:venue/:eventType                                    control
 PUT         /events/:eventId/allocate                                    controllers.EventsController.allocateAssessor(eventId: String)
 
 # Day aggregate events
-GET         /day-aggregate-events/skills/:skillTypes                     controllers.DayAggregateEventController.findBySkillTypes(skillTypes: String)
-GET         /day-aggregate-events/location/:location/skills/:skillTypes  controllers.DayAggregateEventController.findBySkillTypesAndLocation(skillTypes: String, location: String)
+GET         /day-aggregate-events                                        controllers.DayAggregateEventController.findBySkillTypes(skills: List[model.persisted.eventschedules.SkillType.SkillType])
+GET         /day-aggregate-events/location/:location                     controllers.DayAggregateEventController.findBySkillTypesAndLocation(location: String, skills: List[model.persisted.eventschedules.SkillType.SkillType])
 
 # Reference data
 GET         /reference/skills                                            controllers.reference.SkillTypeController.allSkills

--- a/it/repositories/event/EventsRepositorySpec.scala
+++ b/it/repositories/event/EventsRepositorySpec.scala
@@ -50,7 +50,7 @@ class EventsRepositorySpec extends MongoRepositorySpec {
     }
 
     "filter by skills" in {
-      val result = repository.getEvents(None, None, None, Some(List("QAC"))).futureValue
+      val result = repository.getEvents(None, None, None, List(SkillType.QUALITY_ASSURANCE_COORDINATOR)).futureValue
 
       result.size mustBe 1
       result.head.venue mustBe EventExamples.VenueNewcastle
@@ -58,7 +58,7 @@ class EventsRepositorySpec extends MongoRepositorySpec {
     }
 
     "filter by skills and Location" in {
-      val result = repository.getEvents(None, None, Some(EventExamples.LocationNewcastle), Some(List(SkillType.ASSESSOR.toString))).futureValue
+      val result = repository.getEvents(None, None, Some(EventExamples.LocationNewcastle), List(SkillType.ASSESSOR)).futureValue
       result.size mustBe 1
 
       result.head.venue mustBe EventExamples.VenueNewcastle

--- a/test/model/persisted/EventExamples.scala
+++ b/test/model/persisted/EventExamples.scala
@@ -52,7 +52,7 @@ object EventExamples {
     Event(id = UUIDFactory.generateUUID(), eventType = EventType.FSAC, description = "DFS FSB", location = LocationNewcastle,
       venue = VenueNewcastle, date = LocalDate.now(), capacity = 67, minViableAttendees = 60,
       attendeeSafetyMargin = 10, startTime = LocalTime.now(), endTime = LocalTime.now().plusHours(3), skillRequirements = Map(
-        "QAC" -> 1
+        SkillType.QUALITY_ASSURANCE_COORDINATOR.toString-> 1
       ))
 
   )


### PR DESCRIPTION
Accept skill types in routes as a list from query params rather than a comma separated string path segment.