### PR TITLE
Change the 'id' field to 'userId' on assessor allocations

### DIFF
--- a/app/model/command/Allocation.scala
+++ b/app/model/command/Allocation.scala
@@ -22,7 +22,6 @@ import model.exchange.AssessorSkill
 import play.api.libs.json.{ Json, OFormat }
 
 trait Allocation {
-  def userId: String
   def status: AllocationStatus
 }
 
@@ -58,7 +57,7 @@ object AssessorAllocations {
 
     AssessorAllocations(opLock, eventId, o.map { a =>
       val allocatedSkill = AssessorSkill.SkillMap(a.allocatedAs)
-      AssessorAllocation(a.id, a.status, allocatedSkill)
+      AssessorAllocation(a.userId, a.status, allocatedSkill)
     })
   }
 
@@ -68,7 +67,7 @@ object AssessorAllocations {
 }
 
 case class CandidateAllocation(
-                                userId: String,
+                                applicationId: String,
                                 status: AllocationStatus
 ) extends Allocation
 
@@ -101,7 +100,7 @@ object CandidateAllocations {
       version = opLock,
       eventId = eventId,
       sessionId = sessionId,
-      allocations = allocations.map { a => CandidateAllocation(a.id, a.status) }
+      allocations = allocations.map { a => CandidateAllocation(a.applicationId, a.status) }
     )
   }
 

--- a/app/model/command/Allocation.scala
+++ b/app/model/command/Allocation.scala
@@ -22,14 +22,14 @@ import model.exchange.AssessorSkill
 import play.api.libs.json.{ Json, OFormat }
 
 trait Allocation {
-  def id: String
+  def userId: String
   def status: AllocationStatus
 }
 
 case class AssessorAllocation(
-  id: String,
-  status: AllocationStatus,
-  allocatedAs: AssessorSkill
+                               userId: String,
+                               status: AllocationStatus,
+                               allocatedAs: AssessorSkill
 ) extends Allocation
 
 object AssessorAllocation {
@@ -68,8 +68,8 @@ object AssessorAllocations {
 }
 
 case class CandidateAllocation(
-  id: String,
-  status: AllocationStatus
+                                userId: String,
+                                status: AllocationStatus
 ) extends Allocation
 
 object CandidateAllocation {

--- a/app/model/exchange/Allocation.scala
+++ b/app/model/exchange/Allocation.scala
@@ -51,7 +51,7 @@ object AssessorAllocations {
 
       AssessorAllocations(opLock, o.map { a =>
         val allocatedSkill = AssessorSkill.SkillMap(a.allocatedAs)
-        AssessorAllocation(a.id, a.status, allocatedSkill)
+        AssessorAllocation(a.userId, a.status, allocatedSkill)
       })
   }
 }
@@ -64,7 +64,7 @@ case class CandidateAllocation(
 object CandidateAllocation {
   implicit val candidateAllocationFormat: OFormat[CandidateAllocation] = Json.format[CandidateAllocation]
   def fromPersisted(o: model.persisted.CandidateAllocation): CandidateAllocation = {
-    CandidateAllocation(o.id, o.status)
+    CandidateAllocation(o.applicationId, o.status)
   }
 }
 
@@ -83,6 +83,6 @@ object CandidateAllocations {
       case head :: tail => throw new Exception(s"Allocations to this event have mismatching op lock versions ${head ++ tail}")
       case Nil => None
     }
-    CandidateAllocations(opLock, o.map { a => CandidateAllocation(a.id, a.status) })
+    CandidateAllocations(opLock, o.map { a => CandidateAllocation(a.applicationId, a.status) })
   }
 }

--- a/app/model/persisted/Allocation.scala
+++ b/app/model/persisted/Allocation.scala
@@ -43,7 +43,7 @@ object AssessorAllocation {
   implicit val assessorAllocationHandler = Macros.handler[AssessorAllocation]
 
   def fromCommand(o: model.command.AssessorAllocations, opLockVersion: String = UUIDFactory.generateUUID()): Seq[AssessorAllocation] = {
-    o.allocations.map { a => AssessorAllocation(a.id, o.eventId, a.status, a.allocatedAs.name, opLockVersion) }
+    o.allocations.map { a => AssessorAllocation(a.userId, o.eventId, a.status, a.allocatedAs.name, opLockVersion) }
   }
 }
 
@@ -63,7 +63,7 @@ object CandidateAllocation {
     val opLockVersion = UUIDFactory.generateUUID()
     allocations.allocations.map { allocation =>
       CandidateAllocation(
-        id = allocation.id,
+        id = allocation.userId,
         eventId = allocations.eventId,
         sessionId = allocations.sessionId,
         status = allocation.status,

--- a/app/model/persisted/Allocation.scala
+++ b/app/model/persisted/Allocation.scala
@@ -27,6 +27,7 @@ trait Allocation {
   def eventId: String
   def status: AllocationStatus
   def version: String
+  def userQueryKey: String
 }
 
 case class AssessorAllocation(
@@ -35,7 +36,9 @@ case class AssessorAllocation(
                                status: AllocationStatus,
                                allocatedAs: SkillType,
                                version: String
-) extends Allocation
+) extends Allocation {
+  override val userQueryKey = "userId"
+}
 
 object AssessorAllocation {
   implicit val assessorAllocationFormat: OFormat[AssessorAllocation] = Json.format[AssessorAllocation]
@@ -52,7 +55,9 @@ case class CandidateAllocation(
                                 sessionId: String,
                                 status: AllocationStatus,
                                 version: String
-) extends Allocation
+) extends Allocation {
+  override val userQueryKey = "applicationId"
+}
 
 object CandidateAllocation {
   implicit val candidateAllocationFormat: OFormat[CandidateAllocation] = Json.format[CandidateAllocation]

--- a/app/model/persisted/Allocation.scala
+++ b/app/model/persisted/Allocation.scala
@@ -24,18 +24,17 @@ import play.api.libs.json.{ Json, OFormat }
 import reactivemongo.bson.Macros
 
 trait Allocation {
-  def id: String
   def eventId: String
   def status: AllocationStatus
   def version: String
 }
 
 case class AssessorAllocation(
-  id: String,
-  eventId: String,
-  status: AllocationStatus,
-  allocatedAs: SkillType,
-  version: String
+                               userId: String,
+                               eventId: String,
+                               status: AllocationStatus,
+                               allocatedAs: SkillType,
+                               version: String
 ) extends Allocation
 
 object AssessorAllocation {
@@ -48,11 +47,11 @@ object AssessorAllocation {
 }
 
 case class CandidateAllocation(
-  id: String,
-  eventId: String,
-  sessionId: String,
-  status: AllocationStatus,
-  version: String
+                                applicationId: String,
+                                eventId: String,
+                                sessionId: String,
+                                status: AllocationStatus,
+                                version: String
 ) extends Allocation
 
 object CandidateAllocation {
@@ -63,7 +62,7 @@ object CandidateAllocation {
     val opLockVersion = UUIDFactory.generateUUID()
     allocations.allocations.map { allocation =>
       CandidateAllocation(
-        id = allocation.userId,
+        applicationId = allocation.applicationId,
         eventId = allocations.eventId,
         sessionId = allocations.sessionId,
         status = allocation.status,
@@ -75,7 +74,7 @@ object CandidateAllocation {
   def fromExchange(o: model.exchange.CandidateAllocations, eventId: String, sessionId: String) : Seq[CandidateAllocation] = {
     o.allocations.map { a =>
       CandidateAllocation(
-        id = a.id,
+        applicationId = a.id,
         eventId = eventId,
         sessionId = sessionId,
         status = a.status,

--- a/app/model/persisted/Allocation.scala
+++ b/app/model/persisted/Allocation.scala
@@ -28,6 +28,7 @@ trait Allocation {
   def status: AllocationStatus
   def version: String
   def userQueryKey: String
+  def userQueryValue: String
 }
 
 case class AssessorAllocation(
@@ -38,6 +39,7 @@ case class AssessorAllocation(
                                version: String
 ) extends Allocation {
   override val userQueryKey = "userId"
+  override val userQueryValue = userId
 }
 
 object AssessorAllocation {
@@ -57,6 +59,7 @@ case class CandidateAllocation(
                                 version: String
 ) extends Allocation {
   override val userQueryKey = "applicationId"
+  override val userQueryValue = applicationId
 }
 
 object CandidateAllocation {

--- a/app/repositories/AllocationRepository.scala
+++ b/app/repositories/AllocationRepository.scala
@@ -35,7 +35,7 @@ trait AllocationRepository[T <: Allocation] extends ReactiveRepositoryHelpers { 
 
   val projection = BSONDocument("_id" -> false)
 
-  def find(id: String, status: Option[AllocationStatus] = None): Future[Seq[T]] = {
+  def find(id: String, key: String, status: Option[AllocationStatus] = None): Future[Seq[T]] = {
     val query = List(
       Some(BSONDocument("id" -> id)),
       status.map(s => BSONDocument("status" -> s))
@@ -57,10 +57,11 @@ trait AllocationRepository[T <: Allocation] extends ReactiveRepositoryHelpers { 
       eventIds.head
     }
 
-    val assessorOrApplicationId = allocations.map(_.userQueryKey)
+    val userQueryKey = allocations.map(_.userQueryKey).head
+    val userQueryValue = allocations.map(_.userQueryValue)
 
     val query = BSONDocument("$and" -> BSONArray(
-      BSONDocument("id" -> BSONDocument("$in" -> assessorOrApplicationId)),
+      BSONDocument(userQueryKey -> BSONDocument("$in" -> userQueryValue)),
       BSONDocument("eventId" -> eventId)
     ))
 

--- a/app/repositories/AllocationRepository.scala
+++ b/app/repositories/AllocationRepository.scala
@@ -57,7 +57,8 @@ trait AllocationRepository[T <: Allocation] extends ReactiveRepositoryHelpers { 
       eventIds.head
     }
 
-    val assessorOrApplicationId = allocations.map(_.id)
+    val assessorOrApplicationId = allocations.map(_.userQueryKey)
+
     val query = BSONDocument("$and" -> BSONArray(
       BSONDocument("id" -> BSONDocument("$in" -> assessorOrApplicationId)),
       BSONDocument("eventId" -> eventId)

--- a/app/services/allocation/AssessorAllocationService.scala
+++ b/app/services/allocation/AssessorAllocationService.scala
@@ -96,7 +96,7 @@ trait AssessorAllocationService extends EventSink {
             updateExistingAllocations(existingAllocation, newAllocations).flatMap { _ =>
               Future.sequence(
                 newAllocations.allocations
-                  .filter(alloc => !existingIds.contains(alloc.id))
+                  .filter(alloc => !existingIds.contains(alloc.userId))
                   .map(sendCandidateEmail(_, eventDate, eventTime, deadlineDateTime))
               )
             }.map(_ => ())
@@ -109,7 +109,7 @@ trait AssessorAllocationService extends EventSink {
                                  eventDate: String,
                                  eventTime: String,
                                  deadlineDateTime: String)(implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = {
-    applicationRepo.find(candidateAllocation.id).flatMap {
+    applicationRepo.find(candidateAllocation.userId).flatMap {
       case Some(candidate) =>
         eventSink {
           val res = authProviderClient.findByUserIds(Seq(candidate.userId)).map { candidates =>
@@ -124,7 +124,7 @@ trait AssessorAllocationService extends EventSink {
           } recover { case ex => throw new RuntimeException(s"Was not able to retrieve user details for candidate ${candidate.userId}", ex) }
           res.asInstanceOf[Future[StcEvents]]
         }
-      case None => throw new RuntimeException(s"Can not find user application: ${candidateAllocation.id}")
+      case None => throw new RuntimeException(s"Can not find user application: ${candidateAllocation.userId}")
     }
   }
 

--- a/app/services/allocation/AssessorAllocationService.scala
+++ b/app/services/allocation/AssessorAllocationService.scala
@@ -69,7 +69,7 @@ trait AssessorAllocationService extends EventSink {
     candidateAllocationRepo.allocationsForSession(eventId, sessionId).map { a => exchange.CandidateAllocations.apply(a) }
   }
 
-  def allocate(newAllocations: command.AssessorAllocations)(implicit hc: HeaderCarrier): Future[Unit] = {
+  def allocate(newAllocations: command.AssessorAllocations): Future[Unit] = {
     assessorAllocationRepo.allocationsForEvent(newAllocations.eventId).flatMap {
       case Nil => assessorAllocationRepo.save(persisted.AssessorAllocation.fromCommand(newAllocations))
       case existingAllocations => updateExistingAllocations(existingAllocations, newAllocations)

--- a/app/services/allocation/AssessorAllocationService.scala
+++ b/app/services/allocation/AssessorAllocationService.scala
@@ -27,6 +27,8 @@ import model.stc.EmailEvents.{ CandidateAllocationConfirmationRequest, Candidate
 import model.stc.StcEventTypes.StcEvents
 import play.api.mvc.RequestHeader
 import repositories.application.GeneralApplicationRepository
+import repositories.contactdetails.ContactDetailsMongoRepository
+import repositories.personaldetails.PersonalDetailsMongoRepository
 import repositories.{ AssessorAllocationMongoRepository, CandidateAllocationMongoRepository }
 import services.events.EventsService
 import services.stc.{ EventSink, StcEventService }
@@ -67,16 +69,44 @@ trait AssessorAllocationService extends EventSink {
     candidateAllocationRepo.allocationsForSession(eventId, sessionId).map { a => exchange.CandidateAllocations.apply(a) }
   }
 
-  def allocate(newAllocations: command.AssessorAllocations): Future[Unit] = {
+  def allocate(newAllocations: command.AssessorAllocations)(implicit hc: HeaderCarrier): Future[Unit] = {
     assessorAllocationRepo.allocationsForEvent(newAllocations.eventId).flatMap {
-      case Nil => assessorAllocationRepo.save(persisted.AssessorAllocation.fromCommand(newAllocations)).map(_ => ())
-      case existingAllocations => updateExistingAllocations(existingAllocations, newAllocations).map(_ => ())
+      case Nil =>
+        for {
+          _ <- assessorAllocationRepo.save(persisted.AssessorAllocation.fromCommand(newAllocations))
+          _ <- notifyNewlyAllocatedAssessors(newAllocations)
+        } yield ()
+      case existingAllocations => updateExistingAllocations(existingAllocations, newAllocations)
     }
   }
 
   private val dateFormat = "dd MMMM YYYY"
   private val timeFormat = "HH:mma"
 
+  private def notifyNewlyAllocatedAssessors(newAllocations: command.AssessorAllocations)(implicit hc: HeaderCarrier): Future[Unit] = {
+    val x = (for {
+      eventDetails <- eventsService.getEvent(newAllocations.eventId)
+      contactDetails <- authProviderClient.findByUserIds(newAllocations.allocations.map(_.id))
+    } yield for {
+      contactDetail <- contactDetails
+      contactDetailsForUser = contactDetails.find(_.userId == contactDetail.userId).getOrElse(
+        throw new Exception("Could not find contact details for assessor user")
+      )
+      allocationForUser = newAllocations.allocations.find(_.id == contactDetailsForUser.userId).get
+    } yield {
+      emailClient.sendAssessorAllocatedToEvent(
+        contactDetailsForUser.email,
+        contactDetailsForUser.firstName + " " + contactDetailsForUser.lastName,
+        eventDetails.date.toString("d MMMM YYYY"),
+        allocationForUser.allocatedAs.displayText,
+        eventDetails.eventType.toString,
+        eventDetails.location.name,
+        eventDetails.startTime.toString("ha")
+      )
+    }).map(_ => ())
+
+    x
+  }
 
   def allocateCandidates(newAllocations: command.CandidateAllocations)(implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = {
 
@@ -96,7 +126,7 @@ trait AssessorAllocationService extends EventSink {
             updateExistingAllocations(existingAllocation, newAllocations).flatMap { _ =>
               Future.sequence(
                 newAllocations.allocations
-                  .filter(alloc => !existingIds.contains(alloc.userId))
+                  .filter(alloc => !existingIds.contains(alloc.applicationId))
                   .map(sendCandidateEmail(_, eventDate, eventTime, deadlineDateTime))
               )
             }.map(_ => ())
@@ -109,7 +139,7 @@ trait AssessorAllocationService extends EventSink {
                                  eventDate: String,
                                  eventTime: String,
                                  deadlineDateTime: String)(implicit hc: HeaderCarrier, rh: RequestHeader): Future[Unit] = {
-    applicationRepo.find(candidateAllocation.userId).flatMap {
+    applicationRepo.find(candidateAllocation.applicationId).flatMap {
       case Some(candidate) =>
         eventSink {
           val res = authProviderClient.findByUserIds(Seq(candidate.userId)).map { candidates =>
@@ -124,15 +154,16 @@ trait AssessorAllocationService extends EventSink {
           } recover { case ex => throw new RuntimeException(s"Was not able to retrieve user details for candidate ${candidate.userId}", ex) }
           res.asInstanceOf[Future[StcEvents]]
         }
-      case None => throw new RuntimeException(s"Can not find user application: ${candidateAllocation.userId}")
+      case None => throw new RuntimeException(s"Can not find user application: ${candidateAllocation.applicationId}")
     }
   }
 
   private def updateExistingAllocations(existingAllocations: Seq[persisted.AssessorAllocation],
                                         newAllocations: command.AssessorAllocations): Future[Unit] = {
 
+    // If versions match there has been no update from another user while this user was editing, do update
     if (existingAllocations.forall(_.version == newAllocations.version)) {
-      // no prior update since reading so do update
+
       // check what's been updated here so we can send email notifications
       val toPersist = persisted.AssessorAllocation.fromCommand(newAllocations)
       assessorAllocationRepo.delete(existingAllocations).flatMap { _ =>

--- a/app/services/assessoravailability/AssessorService.scala
+++ b/app/services/assessoravailability/AssessorService.scala
@@ -111,7 +111,7 @@ trait AssessorService {
       FutureEx.traverseSerial(allocations) { allocation =>
         eventsRepo.getEvent(allocation.eventId).map { event =>
           AllocationWithEvent(
-            allocation.id,
+            allocation.userId,
             event.id,
             event.date,
             event.startTime,

--- a/it/repositories/AllocationRepositorySpec.scala
+++ b/it/repositories/AllocationRepositorySpec.scala
@@ -68,7 +68,7 @@ trait AllocationRepositorySpec[T <: Allocation] { this: MongoRepositorySpec =>
     "correctly retrieve documents" in {
       repository.save(allocations).futureValue
       allocations.foreach { allocation =>
-        val findResult = repository.find(allocation.id).futureValue
+        val findResult = repository.find(allocation.userQueryValue).futureValue
         findResult mustBe allocation :: Nil
       }
     }


### PR DESCRIPTION
I was working with this case class on a branch and kept getting caught out by 'id' - is it an assessor allocation id? a user id? some other kind of id? So i've changed it to make it clearer

@fayimora @vglushak - i think this is your area of responsibility now :-) do you think i've got everything and it's ok?