### PR TITLE
NoJira - Remove toPassmark calls from TDG

### DIFF
--- a/app/repositories/assessmentcentre/AssessmentCentreRepository.scala
+++ b/app/repositories/assessmentcentre/AssessmentCentreRepository.scala
@@ -58,7 +58,7 @@ class AssessmentCentreMongoRepository (
       "applicationStatus" -> ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED,
       "testGroups.PHASE3.evaluation.result" -> BSONDocument("$elemMatch" -> BSONDocument(
         "schemeId" -> BSONDocument("$nin" -> siftableSchemeIds),
-        "result" -> EvaluationResults.Green.toPassmark
+        "result" -> EvaluationResults.Green.toString
       ))
     )
 

--- a/app/repositories/sift/ApplicationSiftRepository.scala
+++ b/app/repositories/sift/ApplicationSiftRepository.scala
@@ -67,7 +67,7 @@ class ApplicationSiftMongoRepository(
     BSONDocument("applicationStatus" -> prevPhase),
     BSONDocument(s"testGroups.$prevTestGroup.evaluation.result" -> BSONDocument("$elemMatch" ->
       BSONDocument("schemeId" -> BSONDocument("$in" -> siftableSchemeIds),
-      "result" -> EvaluationResults.Green.toPassmark)
+      "result" -> EvaluationResults.Green.toString)
   ))))
 
   def nextApplicationsForSiftStage(batchSize: Int): Future[List[ApplicationForSift]] = {

--- a/app/services/testdata/candidate/onlinetests/TestsPassedStatusGenerator.scala
+++ b/app/services/testdata/candidate/onlinetests/TestsPassedStatusGenerator.scala
@@ -44,7 +44,7 @@ object Phase1TestsPassedStatusGenerator extends TestsPassedStatusGenerator {
     generatorConfig.phase1TestData.flatMap(_.passmarkEvaluation)
       .getOrElse {
         val schemeEvaluation = dgr.schemePreferences.map(_.schemes.map(scheme =>
-          SchemeEvaluationResult(scheme, EvaluationResults.Green.toPassmark))
+          SchemeEvaluationResult(scheme, EvaluationResults.Green.toString))
         ).getOrElse(Nil)
         val passmarkVersion = UUIDFactory.generateUUID().toString
         val resultVersion = UUIDFactory.generateUUID().toString
@@ -66,7 +66,7 @@ object Phase2TestsPassedStatusGenerator extends TestsPassedStatusGenerator {
     generatorConfig.phase2TestData.flatMap(_.passmarkEvaluation)
       .getOrElse {
         val schemeEvaluation = dgr.schemePreferences.map(_.schemes.map(scheme => SchemeEvaluationResult(scheme,
-          EvaluationResults.Green.toPassmark
+          EvaluationResults.Green.toString
         ))).getOrElse(Nil)
         val passmarkVersion = UUIDFactory.generateUUID().toString
         val resultVersion = UUIDFactory.generateUUID().toString
@@ -89,7 +89,7 @@ object Phase3TestsPassedStatusGenerator extends TestsPassedStatusGenerator {
     generatorConfig.phase3TestData.flatMap(_.passmarkEvaluation)
       .getOrElse {
         val schemeEvaluation = dgr.schemePreferences.map(_.schemes.map(scheme => SchemeEvaluationResult(scheme,
-          EvaluationResults.Green.toPassmark
+          EvaluationResults.Green.toString
         ))).getOrElse(Nil)
         val passmarkVersion = UUIDFactory.generateUUID().toString
         val resultVersion = UUIDFactory.generateUUID().toString

--- a/it/repositories/CommonRepository.scala
+++ b/it/repositories/CommonRepository.scala
@@ -112,7 +112,7 @@ trait CommonRepository {
                             ): Future[Unit] = {
     val phase3PassMarkEvaluation = PassmarkEvaluation("", Some(""),
       List(SchemeEvaluationResult(scheme,
-        result.toPassmark)), "", Some(""))
+        result.toString)), "", Some(""))
 
     val launchPadTests = phase3TestWithResults(videoInterviewScore).activeTests
     insertApplication(appId, ApplicationStatus.PHASE3_TESTS, None, None, Some(launchPadTests))

--- a/it/repositories/assessmentcentre/AssessmentCentreRepositorySpec.scala
+++ b/it/repositories/assessmentcentre/AssessmentCentreRepositorySpec.scala
@@ -14,7 +14,6 @@ class AssessmentCentreRepositorySpec extends MongoRepositorySpec with ScalaFutur
   val Commercial: SchemeId = SchemeId("Commercial")
   val European: SchemeId = SchemeId("European")
   val Sdip: SchemeId = SchemeId("Sdip")
-  val Generalist: SchemeId = SchemeId("Generalistt status")
   val ProjectDelivery = SchemeId("Project Delivery")
   val Finance = SchemeId("Finance")
   val DiplomaticService = SchemeId("Diplomatic Service")
@@ -41,9 +40,9 @@ class AssessmentCentreRepositorySpec extends MongoRepositorySpec with ScalaFutur
       whenReady(repository.nextApplicationForAssessmentCentre(10)) { appsForAc =>
         appsForAc mustBe List(
           ApplicationForFsac("appId1", PassmarkEvaluation("", Some(""),
-            List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toPassmark)), "", Some(""))),
+            List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString)), "", Some(""))),
           ApplicationForFsac("appId4", PassmarkEvaluation("", Some(""),
-            List(SchemeEvaluationResult(SchemeId("Project Delivery"), EvaluationResults.Green.toPassmark)), "", Some(""))))
+            List(SchemeEvaluationResult(SchemeId("Project Delivery"), EvaluationResults.Green.toString)), "", Some(""))))
       }
     }
 

--- a/it/repositories/sift/ApplicationSiftRepositorySpec.scala
+++ b/it/repositories/sift/ApplicationSiftRepositorySpec.scala
@@ -46,9 +46,9 @@ class ApplicationSiftRepositorySpec extends MongoRepositorySpec with ScalaFuture
       val appsForSift = repository.nextApplicationsForSiftStage(10).futureValue
       appsForSift mustBe List(
         ApplicationForSift("appId1", PassmarkEvaluation("", Some(""),
-          List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toPassmark)), "", Some(""))),
+          List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString)), "", Some(""))),
         ApplicationForSift("appId4", PassmarkEvaluation("", Some(""),
-          List(SchemeEvaluationResult(SchemeId("Project Delivery"), EvaluationResults.Green.toPassmark)), "", Some(""))))
+          List(SchemeEvaluationResult(SchemeId("Project Delivery"), EvaluationResults.Green.toString)), "", Some(""))))
     }
 
     ("return no results when there are only phase 3 applications that aren't in Passed_Notified which apply for sift or don't have Green/Passed "


### PR DESCRIPTION
TDG and some repos were incorrectly using EvaluationResult.toPassmark to generate scheme evaluation results.