### PR TITLE
Assessors who decline should not get removed email

### DIFF
--- a/app/services/allocation/AssessorAllocationService.scala
+++ b/app/services/allocation/AssessorAllocationService.scala
@@ -105,7 +105,8 @@ trait AssessorAllocationService extends EventSink {
   private def notifyAllocationUnallocatedAssessors(
     allocations: command.AssessorAllocations
   )(implicit hc: HeaderCarrier): Future[Unit] = {
-    getContactDetails(allocations).map { userInfo =>
+    val eligibleAllocations = allocations.copy(allocations = allocations.allocations.filterNot(_.status == AllocationStatuses.DECLINED))
+    getContactDetails(eligibleAllocations).map { userInfo =>
       userInfo.map { case (contactDetailsForUser, eventDetails, _) =>
         emailClient.sendAssessorUnAllocatedFromEvent(
           contactDetailsForUser.email,


### PR DESCRIPTION
When an assessor declines an event, they get removed from the event by the service admin. When this happens, they should not receive an email saying they were removed from an event.

Not sure if we want to merge this in yet. Final confirmation from Kev/Wamiq/Andy is required.

I believe Wamiq wanted me to ignore this because it might be too much work but the diff says otherwise 😉 