### PR TITLE
NoJira: Fix sift form submission and scheme sift when there are withdrawn schemes

### DIFF
--- a/app/repositories/sift/SiftAnswersRepository.scala
+++ b/app/repositories/sift/SiftAnswersRepository.scala
@@ -16,7 +16,7 @@
 
 package repositories.sift
 
-import model.Exceptions.{ SchemeSpecificAnswerNotFound, SiftAnswersIncomplete, SiftAnswersSubmitted }
+import model.Exceptions.{ SiftAnswersIncomplete, SiftAnswersSubmitted }
 import model.SchemeId
 import model.persisted.sift.SiftAnswersStatus.SiftAnswersStatus
 import model.persisted.sift.{ GeneralQuestionsAnswers, SchemeSpecificAnswer, SiftAnswers, SiftAnswersStatus }

--- a/app/services/sift/ApplicationSiftService.scala
+++ b/app/services/sift/ApplicationSiftService.scala
@@ -18,6 +18,7 @@ package services.sift
 
 import common.FutureEx
 import factories.DateTimeFactory
+import model.EvaluationResults.Green
 import model.{ ProgressStatuses, SchemeId, SerialUpdateResult, SiftRequirement }
 import model.command.ApplicationForSift
 import model.persisted.SchemeEvaluationResult
@@ -87,7 +88,8 @@ trait ApplicationSiftService extends CurrentSchemeStatusHelper with CommonBSONDo
     } yield {
       val newSchemeStatus = calculateCurrentSchemeStatus(currentSchemeStatus, result :: Nil)
       val action = s"Sifting application for ${result.schemeId.value}"
-      val candidatesSiftableSchemes = schemeRepo.siftableSchemeIds.filter(s => currentSchemeStatus.map(_.schemeId).contains(s))
+      val candidatesGreenSchemes = currentSchemeStatus.collect { case s if s.result == Green.toString => s.schemeId }
+      val candidatesSiftableSchemes = schemeRepo.siftableSchemeIds.filter(s => candidatesGreenSchemes.contains(s))
       val siftedSchemes = (currentSiftEvaluation.map(_.schemeId) :+ result.schemeId).distinct
 
       val mergedUpdate = Seq(

--- a/it/factories/ITDateTimeFactoryMock.scala
+++ b/it/factories/ITDateTimeFactoryMock.scala
@@ -18,7 +18,7 @@ package factories
 
 import org.joda.time.{ DateTime, LocalDate }
 
-object DateTimeFactoryMock extends  DateTimeFactory {
+object ITDateTimeFactoryMock extends  DateTimeFactory {
   val nowLocalTimeZone: DateTime = DateTime.now()
   val nowLocalDate: LocalDate = LocalDate.now()
 }

--- a/it/repositories/ApplicationRepositorySpec.scala
+++ b/it/repositories/ApplicationRepositorySpec.scala
@@ -17,9 +17,9 @@
 package repositories
 
 import config.MicroserviceAppConfig.cubiksGatewayConfig
-import factories.DateTimeFactoryMock
+import factories.ITDateTimeFactoryMock
 import model.ApplicationStatus._
-import model.{ ApplicationRoute, EvaluationResults, ProgressStatuses }
+import model.{ ApplicationRoute, ProgressStatuses }
 import model.Exceptions.ApplicationNotFound
 import model.command.WithdrawApplication
 import model.persisted.AssistanceDetails
@@ -40,7 +40,7 @@ class ApplicationRepositorySpec extends MongoRepositorySpec {
 
   val collectionName = CollectionNames.APPLICATION
 
-  def applicationRepo = new GeneralApplicationMongoRepository(DateTimeFactoryMock, cubiksGatewayConfig)
+  def applicationRepo = new GeneralApplicationMongoRepository(ITDateTimeFactoryMock, cubiksGatewayConfig)
 
   def assistanceRepo = new AssistanceDetailsMongoRepository()
 

--- a/it/repositories/application/FlagCandidateMongoRepositorySpec.scala
+++ b/it/repositories/application/FlagCandidateMongoRepositorySpec.scala
@@ -16,7 +16,7 @@
 
 package repositories.application
 
-import factories.{ DateTimeFactoryMock, UUIDFactory }
+import factories.{ ITDateTimeFactoryMock, UUIDFactory }
 import model.Exceptions.NotFoundException
 import model.FlagCandidatePersistedObject.FlagCandidate
 import reactivemongo.bson.BSONDocument
@@ -30,7 +30,7 @@ class FlagCandidateMongoRepositorySpec extends MongoRepositorySpec with UUIDFact
 
   val collectionName = CollectionNames.APPLICATION
   def repository = new FlagCandidateMongoRepository
-  def helperRepo = new GeneralApplicationMongoRepository(DateTimeFactoryMock, cubiksGatewayConfig)
+  def helperRepo = new GeneralApplicationMongoRepository(ITDateTimeFactoryMock, cubiksGatewayConfig)
 
   "Flag Candidate repository" should {
     "create and get an issue for the candidate" in {

--- a/it/repositories/application/GeneralApplicationMongoRepositorySpec.scala
+++ b/it/repositories/application/GeneralApplicationMongoRepositorySpec.scala
@@ -16,7 +16,7 @@
 
 package repositories.application
 
-import factories.{ DateTimeFactory, DateTimeFactoryMock, UUIDFactory }
+import factories.{ ITDateTimeFactoryMock, UUIDFactory }
 import model.ApplicationStatus._
 import model.exchange.CandidatesEligibleForEventResponse
 import model.{ ApplicationStatus, Candidate, _ }
@@ -41,9 +41,9 @@ class GeneralApplicationMongoRepositorySpec extends MongoRepositorySpec with UUI
 
   val collectionName = CollectionNames.APPLICATION
 
-  def repository = new GeneralApplicationMongoRepository(DateTimeFactoryMock, cubiksGatewayConfig)
-  def phase1TestRepo = new Phase1TestMongoRepository(DateTimeFactory)
-  def phase2TestRepo = new Phase2TestMongoRepository(DateTimeFactory)
+  def repository = new GeneralApplicationMongoRepository(ITDateTimeFactoryMock, cubiksGatewayConfig)
+  def phase1TestRepo = new Phase1TestMongoRepository(ITDateTimeFactoryMock)
+  def phase2TestRepo = new Phase2TestMongoRepository(ITDateTimeFactoryMock)
   def testDataRepo = new TestDataMongoRepository()
 
   "General Application repository" should {

--- a/it/repositories/application/ReportingMongoRepositorySpec.scala
+++ b/it/repositories/application/ReportingMongoRepositorySpec.scala
@@ -17,7 +17,7 @@
 package repositories.application
 
 import _root_.services.testdata.TestDataGeneratorService
-import factories.{ DateTimeFactoryMock, UUIDFactory }
+import factories.{ ITDateTimeFactoryMock, UUIDFactory }
 import model.ProgressStatuses.{ PHASE3_TESTS_INVITED, PHASE3_TESTS_PASSED_NOTIFIED, SUBMITTED, PHASE1_TESTS_PASSED => _ }
 import model._
 import model.report.{ AdjustmentReportItem, ApplicationDeferralPartialItem, CandidateProgressReportItem }
@@ -42,9 +42,9 @@ class ReportingMongoRepositorySpec extends MongoRepositorySpec with UUIDFactory 
 
   val collectionName = CollectionNames.APPLICATION
 
-  def repository = new ReportingMongoRepository(GBTimeZoneService, DateTimeFactoryMock)
+  def repository = new ReportingMongoRepository(GBTimeZoneService, ITDateTimeFactoryMock)
 
-  def applicationRepo = new GeneralApplicationMongoRepository(DateTimeFactoryMock, cubiksGatewayConfig)
+  def applicationRepo = new GeneralApplicationMongoRepository(ITDateTimeFactoryMock, cubiksGatewayConfig)
 
   def testDataRepo = new TestDataMongoRepository()
 

--- a/it/repositories/onlinetesting/ApplicationDataFixture.scala
+++ b/it/repositories/onlinetesting/ApplicationDataFixture.scala
@@ -1,6 +1,6 @@
 package repositories.onlinetesting
 
-import factories.{ DateTimeFactory, DateTimeFactoryMock }
+import factories.ITDateTimeFactoryMock
 import model.ProgressStatuses.ProgressStatus
 import model.persisted.phase3tests.Phase3TestGroup
 import model.persisted.{ Phase1TestProfile, Phase2TestGroup }
@@ -19,13 +19,13 @@ import repositories.CollectionNames
 trait ApplicationDataFixture {
   this: MongoRepositorySpec =>
 
-  def helperRepo = new GeneralApplicationMongoRepository(DateTimeFactoryMock, cubiksGatewayConfig)
+  def helperRepo = new GeneralApplicationMongoRepository(ITDateTimeFactoryMock, cubiksGatewayConfig)
 
-  def phase1TestRepo = new Phase1TestMongoRepository(DateTimeFactory)
+  def phase1TestRepo = new Phase1TestMongoRepository(ITDateTimeFactoryMock)
 
-  def phase2TestRepo = new Phase2TestMongoRepository(DateTimeFactory)
+  def phase2TestRepo = new Phase2TestMongoRepository(ITDateTimeFactoryMock)
 
-  def phase3TestRepo = new Phase3TestMongoRepository(DateTimeFactory)
+  def phase3TestRepo = new Phase3TestMongoRepository(ITDateTimeFactoryMock)
 
   import ImplicitBSONHandlers._
 

--- a/it/repositories/onlinetesting/Phase1TestRepositorySpec.scala
+++ b/it/repositories/onlinetesting/Phase1TestRepositorySpec.scala
@@ -18,7 +18,7 @@ package repositories.onlinetesting
 
 import java.util.UUID
 
-import factories.DateTimeFactoryMock
+import factories.ITDateTimeFactoryMock
 import model.EvaluationResults.{ Amber, Green, Red }
 import model.Exceptions.{ CannotFindTestByCubiksId, PassMarkEvaluationNotFound }
 import model.OnlineTestCommands.OnlineTestApplication
@@ -61,7 +61,7 @@ class Phase1TestRepositorySpec extends MongoRepositorySpec with ApplicationDataF
       phase1Test.copy(usedForResults = true, resultsReadyToDownload = true))
     )
   )
-  def phase1EvaluationRepo = new Phase1EvaluationMongoRepository(DateTimeFactoryMock)
+  def phase1EvaluationRepo = new Phase1EvaluationMongoRepository(ITDateTimeFactoryMock)
 
   "Get online test" should {
     "return None if there is no test for the specific user id" in {

--- a/it/repositories/schemepreferences/SchemePreferencesRepositorySpec.scala
+++ b/it/repositories/schemepreferences/SchemePreferencesRepositorySpec.scala
@@ -7,7 +7,7 @@ import reactivemongo.bson.BSONDocument
 import reactivemongo.json.ImplicitBSONHandlers
 import repositories.application.GeneralApplicationMongoRepository
 import config.MicroserviceAppConfig._
-import factories.DateTimeFactoryMock
+import factories.ITDateTimeFactoryMock
 import model.SchemeId
 import repositories.CollectionNames
 import testkit.MongoRepositorySpec
@@ -18,7 +18,7 @@ class SchemePreferencesRepositorySpec extends MongoRepositorySpec {
   val collectionName: String = CollectionNames.APPLICATION
 
   def repository = new SchemePreferencesMongoRepository
-  def applicationRepository = new GeneralApplicationMongoRepository(DateTimeFactoryMock, cubiksGatewayConfig)
+  def applicationRepository = new GeneralApplicationMongoRepository(ITDateTimeFactoryMock, cubiksGatewayConfig)
 
   "save and find" should {
     "save and return scheme preferences" in {


### PR DESCRIPTION
When candidate submitting sift forms, only check if all the green siftable schemes have been submitted, rather than all siftable schemes.
When sifting a scheme, check against green schemes in currentSchemeStatus rather than
phase3 results to decide whether to update progress to SIFT_COMPLETE.