### PR TITLE
Fset-1711: Make sure that when assessment centre eval writes to currentSchemeStatus it respects withdraw (uses helper's utility function to combine evaluation-results instead of its own)

### DIFF
--- a/app/model/EvaluationResults.scala
+++ b/app/model/EvaluationResults.scala
@@ -41,7 +41,7 @@ object EvaluationResults {
     def toReportReadableString: String = "Amber"
 
     def +(that: Result): Result = that match {
-      case Green => this
+      case Green => Green
       case Red => Red
       case Amber => this
       case Withdrawn => Withdrawn
@@ -83,10 +83,6 @@ object EvaluationResults {
     val Pass, Fail = Value
   }
 
-  @deprecated("This should be deleted", since = "31/07/2017")
-  case class RuleCategoryResult(location1Scheme1: Result, location1Scheme2: Option[Result],
-    location2Scheme1: Option[Result], location2Scheme2: Option[Result], alternativeScheme: Option[Result])
-
   case class CompetencyAverageResult(
     analysisAndDecisionMakingAverage: Double,
     buildingProductiveRelationshipsAverage: Double,
@@ -99,9 +95,6 @@ object EvaluationResults {
       leadingAndCommunicatingAverage, strategicApproachToObjectivesAverage
     )
   }
-
-  @deprecated("Use SchemeEvaluationResult with SchemeId", since = "10/10/2016")
-  case class PerSchemeEvaluation(schemeName: String, result: Result)
 
   case class AssessmentEvaluationResult(
     passedMinimumCompetencyLevel: Option[Boolean],

--- a/app/repositories/CurrentSchemeStatusHelper.scala
+++ b/app/repositories/CurrentSchemeStatusHelper.scala
@@ -19,7 +19,6 @@ package repositories
 import model.EvaluationResults._
 import model.SchemeId
 import model.persisted.SchemeEvaluationResult
-import play.api.Logger
 import reactivemongo.bson.BSONDocument
 
 import scala.annotation.tailrec

--- a/app/repositories/CurrentSchemeStatusHelper.scala
+++ b/app/repositories/CurrentSchemeStatusHelper.scala
@@ -19,6 +19,7 @@ package repositories
 import model.EvaluationResults._
 import model.SchemeId
 import model.persisted.SchemeEvaluationResult
+import play.api.Logger
 import reactivemongo.bson.BSONDocument
 
 import scala.annotation.tailrec

--- a/app/repositories/application/GeneralApplicationRepository.scala
+++ b/app/repositories/application/GeneralApplicationRepository.scala
@@ -967,12 +967,4 @@ class GeneralApplicationMongoRepository(
     case Some(r) => BSONDocument(name -> r)
     case _ => BSONDocument.empty
   }
-
-  private def perSchemeToBSON(name: String, result: Option[List[PerSchemeEvaluation]]): BSONDocument = result match {
-    case Some(m) =>
-      val schemes = m.map(x => BSONDocument(x.schemeName -> x.result.toString))
-      val schemesDoc = schemes.foldRight(BSONDocument.empty)((acc, doc) => acc.add(doc))
-      BSONDocument(name -> schemesDoc)
-    case _ => BSONDocument.empty
-  }
 }

--- a/app/services/assessmentcentre/AssessmentCentreService.scala
+++ b/app/services/assessmentcentre/AssessmentCentreService.scala
@@ -24,7 +24,7 @@ import model.exchange.passmarksettings.AssessmentCentrePassMarkSettings
 import model.persisted.SchemeEvaluationResult
 import model.persisted.fsac.{ AnalysisExercise, AssessmentCentreTests }
 import play.api.Logger
-import repositories.AssessmentScoresRepository
+import repositories.{ AssessmentScoresRepository, CurrentSchemeStatusHelper }
 import repositories.application.GeneralApplicationRepository
 import repositories.assessmentcentre.AssessmentCentreRepository
 import services.assessmentcentre.AssessmentCentreService.CandidateAlreadyHasAnAnalysisExerciseException
@@ -45,7 +45,7 @@ object AssessmentCentreService extends AssessmentCentreService {
   case class CandidateHasNoAnalysisExerciseException(message: String) extends Exception(message)
 }
 
-trait AssessmentCentreService {
+trait AssessmentCentreService extends CurrentSchemeStatusHelper {
   def applicationRepo: GeneralApplicationRepository
   def assessmentCentreRepo: AssessmentCentreRepository
   def passmarkService: PassMarkSettingsService[AssessmentCentrePassMarkSettings]
@@ -140,12 +140,6 @@ trait AssessmentCentreService {
       Logger.debug(s"After evaluation newSchemeStatus = $newSchemeStatus for applicationId: $applicationId")
       newSchemeStatus
     }
-  }
-
-  def calculateCurrentSchemeStatus(existingEvaluations: Seq[SchemeEvaluationResult],
-    newEvaluations: Seq[SchemeEvaluationResult]): Seq[SchemeEvaluationResult] = {
-    val notUpdated = existingEvaluations.filterNot( existingEvaluation => newEvaluations.exists(_.schemeId == existingEvaluation.schemeId))
-    newEvaluations ++ notUpdated
   }
 
   def getTests(applicationId: String): Future[AssessmentCentreTests] = {

--- a/test/model/EvaluationResultsSpec.scala
+++ b/test/model/EvaluationResultsSpec.scala
@@ -67,7 +67,7 @@ class EvaluationResultsSpec extends UnitSpec with TableDrivenPropertyChecks {
         ("addend", "sum"),
         (Red, Red),
         (Amber, Amber),
-        (Green, Amber),
+        (Green, Green),
         (Withdrawn, Withdrawn)
       )
 


### PR DESCRIPTION
This PR does change how Ambers and Greens are combined during formation of the currentSchemeStatus, this was deemed safe after discussions with Ben and Ian