### PR TITLE
FSET-1711: Mark candidates as pass or fail after assessment centre evaluation

### DIFF
--- a/app/repositories/CurrentSchemeStatusHelper.scala
+++ b/app/repositories/CurrentSchemeStatusHelper.scala
@@ -79,31 +79,14 @@ trait CurrentSchemeStatusHelper {
       """.stripMargin)
   }
 
-  def firstResidualPreference(results: Seq[SchemeEvaluationResult]): SchemeEvaluationResult = {
+  def firstResidualPreference(results: Seq[SchemeEvaluationResult]): Option[SchemeEvaluationResult] = {
     val resultsWithIndex = results.zipWithIndex
 
     resultsWithIndex.filterNot { case (result, idx) =>
         result.result == Red.toString || result.result == Withdrawn.toString
-    }
-
-    resultsWithIndex.minBy(_._2)._1
-  }
-
-  def firstResidualPreferencePassed: Boolean = {
-
-    val zippedData = userDataWithSchemes.rawSchemesStatus.zipWithIndex
-
-    val firstAmber: Option[(SchemeEvaluationResult, Int)] =
-      zippedData.find{ case (evaluationResult, _) => evaluationResult.result == SchemeStatus.Amber.toString }
-
-    val firstGreen: Option[(SchemeEvaluationResult, Int)] =
-      zippedData.find{ case (evaluationResult, _) => evaluationResult.result == SchemeStatus.Green.toString }
-
-    (firstAmber, firstGreen) match {
-      case (Some((_, amberIndex)), Some((_, greenIndex))) => greenIndex < amberIndex
-      case (None, Some(green)) => true
-      case _ => false
+    } match {
+      case Nil => None
+      case list => Some(list.minBy(_._2)._1)
     }
   }
-
 }

--- a/app/repositories/CurrentSchemeStatusHelper.scala
+++ b/app/repositories/CurrentSchemeStatusHelper.scala
@@ -19,6 +19,7 @@ package repositories
 import model.EvaluationResults._
 import model.SchemeId
 import model.persisted.SchemeEvaluationResult
+import play.api.Logger
 import reactivemongo.bson.BSONDocument
 
 import scala.annotation.tailrec
@@ -82,9 +83,15 @@ trait CurrentSchemeStatusHelper {
   def firstResidualPreference(results: Seq[SchemeEvaluationResult]): Option[SchemeEvaluationResult] = {
     val resultsWithIndex = results.zipWithIndex
 
-    resultsWithIndex.filterNot { case (result, idx) =>
+    Logger.debug("========= Pre AORG = " + resultsWithIndex)
+
+    val amberOrGreenPreferences = resultsWithIndex.filterNot { case (result, idx) =>
         result.result == Red.toString || result.result == Withdrawn.toString
-    } match {
+    }
+
+    Logger.debug("========= AORG = " + amberOrGreenPreferences)
+
+    amberOrGreenPreferences match {
       case Nil => None
       case list => Some(list.minBy(_._2)._1)
     }

--- a/app/repositories/CurrentSchemeStatusHelper.scala
+++ b/app/repositories/CurrentSchemeStatusHelper.scala
@@ -79,4 +79,31 @@ trait CurrentSchemeStatusHelper {
       """.stripMargin)
   }
 
+  def firstResidualPreference(results: Seq[SchemeEvaluationResult]): SchemeEvaluationResult = {
+    val resultsWithIndex = results.zipWithIndex
+
+    resultsWithIndex.filterNot { case (result, idx) =>
+        result.result == Red.toString || result.result == Withdrawn.toString
+    }
+
+    resultsWithIndex.minBy(_._2)._1
+  }
+
+  def firstResidualPreferencePassed: Boolean = {
+
+    val zippedData = userDataWithSchemes.rawSchemesStatus.zipWithIndex
+
+    val firstAmber: Option[(SchemeEvaluationResult, Int)] =
+      zippedData.find{ case (evaluationResult, _) => evaluationResult.result == SchemeStatus.Amber.toString }
+
+    val firstGreen: Option[(SchemeEvaluationResult, Int)] =
+      zippedData.find{ case (evaluationResult, _) => evaluationResult.result == SchemeStatus.Green.toString }
+
+    (firstAmber, firstGreen) match {
+      case (Some((_, amberIndex)), Some((_, greenIndex))) => greenIndex < amberIndex
+      case (None, Some(green)) => true
+      case _ => false
+    }
+  }
+
 }

--- a/app/repositories/CurrentSchemeStatusHelper.scala
+++ b/app/repositories/CurrentSchemeStatusHelper.scala
@@ -19,7 +19,6 @@ package repositories
 import model.EvaluationResults._
 import model.SchemeId
 import model.persisted.SchemeEvaluationResult
-import play.api.Logger
 import reactivemongo.bson.BSONDocument
 
 import scala.annotation.tailrec
@@ -83,13 +82,9 @@ trait CurrentSchemeStatusHelper {
   def firstResidualPreference(results: Seq[SchemeEvaluationResult]): Option[SchemeEvaluationResult] = {
     val resultsWithIndex = results.zipWithIndex
 
-    Logger.debug("========= Pre AORG = " + resultsWithIndex)
-
     val amberOrGreenPreferences = resultsWithIndex.filterNot { case (result, idx) =>
         result.result == Red.toString || result.result == Withdrawn.toString
     }
-
-    Logger.debug("========= AORG = " + amberOrGreenPreferences)
 
     amberOrGreenPreferences match {
       case Nil => None

--- a/app/services/assessmentcentre/AssessmentCentreService.scala
+++ b/app/services/assessmentcentre/AssessmentCentreService.scala
@@ -146,10 +146,11 @@ trait AssessmentCentreService extends CurrentSchemeStatusHelper {
           // No greens or ambers (i.e. all red or withdrawn)
           case None =>
             applicationRepo.addProgressStatusAndUpdateAppStatus(applicationId.toString(), ASSESSMENT_CENTRE_FAILED)
+          case _ => Future.successful(())
         }
       } else {
         // Don't move anyone not in a SCORES_ACCEPTED status
-        Future.successful()
+        Future.successful(())
       }
 
   }

--- a/test/services/assessmentcentre/AssessmentCentreServiceSpec.scala
+++ b/test/services/assessmentcentre/AssessmentCentreServiceSpec.scala
@@ -18,9 +18,10 @@ package services.assessmentcentre
 
 import config.AssessmentEvaluationMinimumCompetencyLevel
 import model.EvaluationResults._
+import model.ProgressStatuses.{ ASSESSMENT_CENTRE_PASSED, ASSESSMENT_CENTRE_SCORES_ACCEPTED }
 import model._
 import model.assessmentscores.AssessmentScoresAllExercises
-import model.command.ApplicationForFsac
+import model.command.{ ApplicationForFsac, ApplicationStatusDetails }
 import model.exchange.passmarksettings._
 import model.persisted.SchemeEvaluationResult
 import model.persisted.fsac.{ AnalysisExercise, AssessmentCentreTests }
@@ -138,6 +139,14 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
         .expects(*, *)
         .returning(evaluationResult)
 
+      (mockAppRepo.findStatus _)
+        .expects(applicationId.toString())
+        .returningAsync(scoresAcceptedApplicationStatusDetails)
+
+      (mockAppRepo.addProgressStatusAndUpdateAppStatus _)
+        .expects(applicationId.toString(), ASSESSMENT_CENTRE_PASSED)
+        .returning(Future.successful(()))
+
       val currentSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Amber.toString),
         SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
       (mockAppRepo.getCurrentSchemeStatus _)
@@ -168,6 +177,10 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
         .expects(*, *)
         .returning(evaluationResult)
 
+      (mockAppRepo.findStatus _)
+        .expects(applicationId.toString())
+        .returningAsync(scoresAcceptedApplicationStatusDetails)
+      
       val currentSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Green.toString),
         SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
       (mockAppRepo.getCurrentSchemeStatus _)
@@ -197,6 +210,14 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
       (mockEvaluationEngine.evaluate _)
         .expects(*, *)
         .returning(evaluationResult)
+
+      (mockAppRepo.findStatus _)
+        .expects(applicationId.toString())
+        .returningAsync(scoresAcceptedApplicationStatusDetails)
+
+      (mockAppRepo.addProgressStatusAndUpdateAppStatus _)
+        .expects(applicationId.toString(), ASSESSMENT_CENTRE_PASSED)
+        .returning(Future.successful(()))
 
       val currentSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Green.toString),
         SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
@@ -242,6 +263,13 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
         List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString))),
       ApplicationForFsac("appId3", ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED,
         List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString)))
+    )
+
+    val scoresAcceptedApplicationStatusDetails = ApplicationStatusDetails(
+      ASSESSMENT_CENTRE_SCORES_ACCEPTED.toString,
+      ApplicationRoute.Faststream,
+      None,
+      None
     )
 
     def progressToAssessmentCentreMocks = {

--- a/test/services/assessmentcentre/AssessmentCentreServiceSpec.scala
+++ b/test/services/assessmentcentre/AssessmentCentreServiceSpec.scala
@@ -244,7 +244,7 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
       service.evaluateAssessmentCandidate(assessmentData, config).futureValue
     }
 
-    "save evaluation result to red with current status green updated to red and current scheme status being all red" in new TestFixture {
+    "save evaluation result to red with current status green updated to red and current scheme status containing ambers" in new TestFixture {
       val schemeEvaluationResult = List(SchemeEvaluationResult(SchemeId("Commercial"), Red.toString))
       val evaluationResult = AssessmentEvaluationResult(
         passedMinimumCompetencyLevel = Some(true), competencyAverageResult, schemeEvaluationResult)
@@ -257,18 +257,14 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
         .expects(applicationId.toString())
         .returningAsync(scoresAcceptedApplicationStatusDetails)
 
-      (mockAppRepo.addProgressStatusAndUpdateAppStatus _)
-        .expects(applicationId.toString(), ASSESSMENT_CENTRE_FAILED)
-        .returning(Future.successful(()))
-
-      val currentSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Red.toString),
-        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
+      val currentSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Green.toString),
+        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Amber.toString))
       (mockAppRepo.getCurrentSchemeStatus _)
         .expects(applicationId.toString())
         .returning(Future.successful(currentSchemeStatus))
 
       val newSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Red.toString),
-        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
+        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Amber.toString))
       val expectedEvaluation = AssessmentPassMarkEvaluation(applicationId, "1", AssessmentEvaluationResult(
         passedMinimumCompetencyLevel = Some(true), competencyAverageResult, schemeEvaluationResult))
 

--- a/test/services/assessmentcentre/AssessmentCentreServiceSpec.scala
+++ b/test/services/assessmentcentre/AssessmentCentreServiceSpec.scala
@@ -18,7 +18,7 @@ package services.assessmentcentre
 
 import config.AssessmentEvaluationMinimumCompetencyLevel
 import model.EvaluationResults._
-import model.ProgressStatuses.{ ASSESSMENT_CENTRE_PASSED, ASSESSMENT_CENTRE_SCORES_ACCEPTED }
+import model.ProgressStatuses.{ ASSESSMENT_CENTRE_FAILED, ASSESSMENT_CENTRE_PASSED, ASSESSMENT_CENTRE_SCORES_ACCEPTED }
 import model._
 import model.assessmentscores.AssessmentScoresAllExercises
 import model.command.{ ApplicationForFsac, ApplicationStatusDetails }
@@ -180,7 +180,11 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
       (mockAppRepo.findStatus _)
         .expects(applicationId.toString())
         .returningAsync(scoresAcceptedApplicationStatusDetails)
-      
+
+      (mockAppRepo.addProgressStatusAndUpdateAppStatus _)
+        .expects(applicationId.toString(), ASSESSMENT_CENTRE_FAILED)
+        .returning(Future.successful(()))
+
       val currentSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Green.toString),
         SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
       (mockAppRepo.getCurrentSchemeStatus _)
@@ -226,6 +230,44 @@ class AssessmentCentreServiceSpec extends ScalaMockUnitSpec {
         .returning(Future.successful(currentSchemeStatus))
 
       val newSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Green.toString),
+        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
+      val expectedEvaluation = AssessmentPassMarkEvaluation(applicationId, "1", AssessmentEvaluationResult(
+        passedMinimumCompetencyLevel = Some(true), competencyAverageResult, schemeEvaluationResult))
+
+      (mockAssessmentCentreRepo.saveAssessmentScoreEvaluation _)
+        .expects(expectedEvaluation, newSchemeStatus)
+        .returning(Future.successful(()))
+
+      val assessmentData = AssessmentPassMarksSchemesAndScores(passmark = passMarkSettings, schemes = List(SchemeId("Commercial")),
+        scores = AssessmentScoresAllExercises(applicationId = applicationId))
+      val config = AssessmentEvaluationMinimumCompetencyLevel(enabled = false, None)
+      service.evaluateAssessmentCandidate(assessmentData, config).futureValue
+    }
+
+    "save evaluation result to red with current status green updated to red and current scheme status being all red" in new TestFixture {
+      val schemeEvaluationResult = List(SchemeEvaluationResult(SchemeId("Commercial"), Red.toString))
+      val evaluationResult = AssessmentEvaluationResult(
+        passedMinimumCompetencyLevel = Some(true), competencyAverageResult, schemeEvaluationResult)
+
+      (mockEvaluationEngine.evaluate _)
+        .expects(*, *)
+        .returning(evaluationResult)
+
+      (mockAppRepo.findStatus _)
+        .expects(applicationId.toString())
+        .returningAsync(scoresAcceptedApplicationStatusDetails)
+
+      (mockAppRepo.addProgressStatusAndUpdateAppStatus _)
+        .expects(applicationId.toString(), ASSESSMENT_CENTRE_FAILED)
+        .returning(Future.successful(()))
+
+      val currentSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Red.toString),
+        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
+      (mockAppRepo.getCurrentSchemeStatus _)
+        .expects(applicationId.toString())
+        .returning(Future.successful(currentSchemeStatus))
+
+      val newSchemeStatus = List(SchemeEvaluationResult(SchemeId("Commercial"), Red.toString),
         SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString))
       val expectedEvaluation = AssessmentPassMarkEvaluation(applicationId, "1", AssessmentEvaluationResult(
         passedMinimumCompetencyLevel = Some(true), competencyAverageResult, schemeEvaluationResult))


### PR DESCRIPTION
Please merge this first: https://github.com/hmrc/fset-faststream/pull/494

If candidate is in ASSESSMENT_CENTRE_SCORES_ACCEPTED:
   And First residual preference = Green => Pass
   Amber => No action
   No first residual preference (all reds or withdrawn) => Fail