### PR TITLE
Updated scheme names (and remove International)

### DIFF
--- a/conf/schemes.yaml
+++ b/conf/schemes.yaml
@@ -9,7 +9,7 @@
   siftEvaluationRequired: true
 - id: DigitalAndTechnology
   code: DAT
-  name: Digital And Technology
+  name: Digital, Data & Technology
   civilServantEligible: true
   degree:
     required: Degree_21_PostGrad
@@ -27,6 +27,16 @@
   siftRequirement: FORM
   siftEvaluationRequired: true
   fsbType: FCO
+- id: DiplomaticServiceEconomists
+  code: GES-DS
+  name: Diplomatic Service (Economists)
+  civilServantEligible: false
+  degree:
+    required: Degree_DipServEconomics
+    specificRequirement: true
+  siftRequirement: FORM
+  siftEvaluationRequired: true
+  fsbType: EAC_DS
 - id: Finance
   code: FIFS
   name: Finance
@@ -64,16 +74,6 @@
   siftRequirement: FORM
   siftEvaluationRequired: true
   fsbType: EAC
-- id: GovernmentEconomicsServiceDiplomaticService
-  code: GES-DS
-  name: Government Economics Service - Diplomatic Service
-  civilServantEligible: false
-  degree:
-    required: Degree_DipServEconomics
-    specificRequirement: true
-  siftRequirement: FORM
-  siftEvaluationRequired: true
-  fsbType: EAC_DS
 - id: GovernmentOperationalResearchService
   code: GORS
   name: Government Operational Research Service
@@ -122,15 +122,6 @@
     required: Degree_22
     specificRequirement: false
   siftEvaluationRequired: false
-- id: International
-  code: IFS
-  name: International
-  civilServantEligible: true
-  degree:
-    required: Degree_22
-    specificRequirement: true
-  siftRequirement: FORM
-  siftEvaluationRequired: true
 - id: ProjectDelivery
   code: PDFS
   name: Project Delivery

--- a/test/repositories/CurrentSchemeStatusHelperSpec.scala
+++ b/test/repositories/CurrentSchemeStatusHelperSpec.scala
@@ -30,21 +30,21 @@ class CurrentSchemeStatusHelperSpec extends UnitSpec {
     "update status when one does not exist" in {
       val currentStatus = Nil
       val newStatus = SchemeEvaluationResult(SchemeId("Commercial"), Green.toString) ::
-        SchemeEvaluationResult(SchemeId("International"), Red.toString) :: Nil
+        SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), Red.toString) :: Nil
 
       helper.calculateCurrentSchemeStatus(currentStatus, newStatus) mustBe newStatus
     }
 
     "update existing statuses" in {
       val currentStatus = SchemeEvaluationResult(SchemeId("Commercial"), Green.toString) ::
-        SchemeEvaluationResult(SchemeId("International"), Green.toString) :: Nil
+        SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), Green.toString) :: Nil
 
       val newStatus = SchemeEvaluationResult(SchemeId("Commercial"), Red.toString) ::
        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString) :: Nil
 
       helper.calculateCurrentSchemeStatus(currentStatus, newStatus) mustBe
        SchemeEvaluationResult(SchemeId("Commercial"), Red.toString) ::
-       SchemeEvaluationResult(SchemeId("International"), Green.toString) ::
+       SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), Green.toString) ::
        SchemeEvaluationResult(SchemeId("DigitalAndTechnology"), Red.toString) :: Nil
     }
 

--- a/test/services/sift/ApplicationSiftServiceSpec.scala
+++ b/test/services/sift/ApplicationSiftServiceSpec.scala
@@ -42,7 +42,7 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitSpec {
         Scheme("DigitalAndTechnology", "DaT", "Digital and Technology", civilServantEligible = false, None, Some(SiftRequirement.FORM),
           siftEvaluationRequired = true, fsbType = None, telephoneInterviewType = None
         ),
-        Scheme("International", "INT", "International", civilServantEligible = false, None, Some(SiftRequirement.FORM),
+        Scheme("GovernmentSocialResearchService", "GSR", "GovernmentSocialResearchService", civilServantEligible = false, None, Some(SiftRequirement.FORM),
           siftEvaluationRequired = true, fsbType = None, telephoneInterviewType = None
         ),
         Scheme("Commercial", "GCS", "Commercial", civilServantEligible = false, None, Some(SiftRequirement.NUMERIC_TEST),
@@ -50,7 +50,7 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitSpec {
         )
       )
 
-      override def siftableSchemeIds: Seq[SchemeId] = Seq(SchemeId("International"), SchemeId("Commercial"))
+      override def siftableSchemeIds: Seq[SchemeId] = Seq(SchemeId("GovernmentSocialResearchService"), SchemeId("Commercial"))
     }
 
     val service = new ApplicationSiftService {
@@ -75,7 +75,7 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitSpec {
         }
       )
 
-    val schemeSiftResult = SchemeEvaluationResult(SchemeId("International"), EvaluationResults.Green.toString)
+    val schemeSiftResult = SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Green.toString)
     val queryBson = BSONDocument("applicationId" -> appId)
     val updateBson = BSONDocument("test" -> "test")
     (mockSiftRepo.getSiftEvaluations _).expects(appId).returningAsync(Nil)
@@ -125,7 +125,7 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitSpec {
       )
 
       (mockAppRepo.getCurrentSchemeStatus _).expects(appId).returningAsync(Seq(
-        SchemeEvaluationResult(SchemeId("International"), EvaluationResults.Green.toString)
+        SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Green.toString)
       ))
       (mockSiftRepo.siftApplicationForScheme _).expects(appId, schemeSiftResult, expectedUpdateBson).returningAsync
       (mockAppRepo.getApplicationRoute _).expects(appId).returningAsync(ApplicationRoute.Faststream)
@@ -135,13 +135,13 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitSpec {
     }
 
     "sift and update progress status for an SdipFaststream candidate" in new SiftUpdateTest {
-      override val schemeSiftResult = SchemeEvaluationResult(SchemeId("International"), EvaluationResults.Red.toString)
+      override val schemeSiftResult = SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Red.toString)
       val expectedUpdateBson = Seq(
         currentSchemeUpdateBson(schemeSiftResult :: SchemeEvaluationResult(SchemeId("Sdip"), EvaluationResults.Green.toString) :: Nil : _*),
         progressStatusUpdateBson
       )
       (mockAppRepo.getCurrentSchemeStatus _).expects(appId).returningAsync(Seq(
-        SchemeEvaluationResult(SchemeId("International"), EvaluationResults.Green.toString),
+        SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Green.toString),
         SchemeEvaluationResult(SchemeId("Sdip"), EvaluationResults.Green.toString)
       ))
       (mockSiftRepo.siftApplicationForScheme _).expects(appId, schemeSiftResult, expectedUpdateBson).returningAsync
@@ -152,7 +152,7 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitSpec {
 
     "sift a candidate with remaining schemes to sift" in new SiftUpdateTest {
        val currentStatus = Seq(
-        SchemeEvaluationResult(SchemeId("International"), EvaluationResults.Green.toString),
+        SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Green.toString),
         SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString)
       )
       val expectedUpdateBson = Seq(


### PR DESCRIPTION
This removes International as a scheme, updates DaT to Digital, Data & Technology, and gives GES_DS its proper name of Diplomatic Service (Economists). Also updated year for SDIP. This PR has corresponding frontend changes.