### PR TITLE
NoJira: Fix case for SdipFaststream where Sdip is sifted before the FS schemes

### DIFF
--- a/app/services/sift/ApplicationSiftService.scala
+++ b/app/services/sift/ApplicationSiftService.scala
@@ -100,7 +100,8 @@ trait ApplicationSiftService extends CurrentSchemeStatusHelper with CommonBSONDo
   }
 
   private def maybeSetProgressStatus(siftedSchemes: Set[SchemeId], siftableSchemes: Set[SchemeId]) = {
-    if (siftedSchemes equals siftableSchemes) {
+    //  siftedSchemes may contain Sdip if it's been sifted before FS schemes, but we want to ignore it.
+    if (siftableSchemes subsetOf siftedSchemes) {
       progressStatusOnlyBSON(ProgressStatuses.SIFT_COMPLETED)
     } else {
       BSONDocument.empty


### PR DESCRIPTION
and the candidate was not being marked as SIFT_COMPLETE.