### PR TITLE
Rewrite logic for sending daily summary emails to assessors

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -393,7 +393,7 @@ scheduling {
     enabled = false
     lockId = "notify-assessors-of-new-events-job-lock-coordinator"
     initialDelaySecs = 30
-    intervalSecs = 86400
+    intervalSecs = 3600
   }
   remind-candidate-event-allocated {
     enabled = false


### PR DESCRIPTION
@henricook The guards in for-comprehensions don't work as we expected so I have re-written the logic for this