### PR TITLE
NOJIRA: Make sdipfaststream exclusion from sift configurable

### DIFF
--- a/app/config/microserviceAppConfig.scala
+++ b/app/config/microserviceAppConfig.scala
@@ -154,6 +154,7 @@ trait MicroserviceAppConfig extends ServicesConfig with RunMode {
   lazy val userManagementConfig = underlyingConfiguration.as[UserManagementConfig]("microservice.services.user-management")
   lazy val cubiksGatewayConfig = underlyingConfiguration.as[CubiksGatewayConfig]("microservice.services.cubiks-gateway")
   lazy val launchpadGatewayConfig = underlyingConfiguration.as[LaunchpadGatewayConfig]("microservice.services.launchpad-gateway")
+  lazy val disableSdipFaststreamForSift = underlyingConfiguration.as[Boolean]("microservice.services.disableSdipFaststreamForSift")
   lazy val maxNumberOfDocuments = underlyingConfiguration.as[Int]("maxNumberOfDocuments")
 
   lazy val locationsAndVenuesConfig =

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -172,6 +172,7 @@ microservice {
         minimumCompetencyLevelScore = 2.0
       }
     }
+    disableSdipFaststreamForSift = true
   }
 }
 


### PR DESCRIPTION
There are future tickets for QA which need sdipfaststream candidates to proceed past sift, thanks to the existing hotfix this is impossible, which is delaying QA. Make it configurable so we can turn it off in QA.