### PR TITLE
FSET-1820: Do not hold in sift if only sdip is siftable

### DIFF
--- a/app/model/Scheme.scala
+++ b/app/model/Scheme.scala
@@ -82,7 +82,10 @@ case class Scheme(
 object Scheme {
 
   val Sdip = "Sdip"
+  val SdipId = SchemeId(Sdip)
   val Edip = "Edip"
+  val EdipId = SchemeId(Edip)
+
   implicit val schemeFormat: OFormat[Scheme] = Json.format[Scheme]
 
   // scalastyle:off parameter.number

--- a/app/services/sift/ApplicationSiftService.scala
+++ b/app/services/sift/ApplicationSiftService.scala
@@ -117,9 +117,9 @@ trait ApplicationSiftService extends CurrentSchemeStatusHelper with CommonBSONDo
     }) flatMap identity
   }
 
-  private def maybeSetProgressStatus(siftedSchemes: Set[SchemeId], siftableSchemes: Set[SchemeId]) = {
-    //  siftedSchemes may contain Sdip if it's been sifted before FS schemes, but we want to ignore it.
-    if (siftableSchemes subsetOf siftedSchemes) {
+  private def maybeSetProgressStatus(siftedSchemes: Set[SchemeId], candidatesSiftableSchemes: Set[SchemeId]) = {
+    //  siftedSchemes may contain Sdip if it's been sifted before FS schemes, but we want to ignore it. (see schemeFilter)
+    if (candidatesSiftableSchemes subsetOf siftedSchemes) {
       progressStatusOnlyBSON(ProgressStatuses.SIFT_COMPLETED)
     } else {
       BSONDocument.empty


### PR DESCRIPTION
Sdip gets sifted later.

There was already code to deal with this *when another scheme got sifted by a sifter in the admin frontend* - but if Sdip is your *only* siftable scheme that's not going to happen. This handles that scenario, where your only siftable scheme is Sdip.