### PR TITLE
Test data generator fix for QAC user

### DIFF
--- a/app/services/testdata/TestDataGeneratorService.scala
+++ b/app/services/testdata/TestDataGeneratorService.scala
@@ -87,7 +87,7 @@ trait TestDataGeneratorService extends MongoDbConnection {
       _ <- RegisteredStatusGenerator.createUser(
         1,
         "test_qac@mailinator.com", "CSR Test", "QAC", Some("TestServiceManager"),
-        List(AuthProviderClient.QacRole)
+        List(AuthProviderClient.AssessorRole)
       )
       _ <- RegisteredStatusGenerator.createUser(
         1,


### PR DESCRIPTION
Fix for test data generator qac user - set him to the correct role so we can now use him