### PR TITLE
FSET-1837: Modify endpoint for multiple assessors' allocations from GET to POST

### DIFF
--- a/app/connectors/exchange/AssessorAllocationRequest.scala
+++ b/app/connectors/exchange/AssessorAllocationRequest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.exchange
+
+import play.api.libs.json.{ Json, OFormat }
+
+case class AssessorAllocationRequest(assessorIds: Seq[String], status: Option[String])
+
+object AssessorAllocationRequest {
+  implicit val format: OFormat[AssessorAllocationRequest] = Json.format[AssessorAllocationRequest]
+}

--- a/app/controllers/AssessorController.scala
+++ b/app/controllers/AssessorController.scala
@@ -16,9 +16,10 @@
 
 package controllers
 
+import connectors.exchange.AssessorAllocationRequest
 import model.AllocationStatuses.AllocationStatus
 import model.Exceptions._
-import model.{ SerialUpdateResult, UniqueIdentifier }
+import model.{ AllocationStatuses, UniqueIdentifier }
 import model.exchange._
 import model.persisted.eventschedules.SkillType.SkillType
 import org.joda.time.LocalDate
@@ -94,9 +95,11 @@ trait AssessorController extends BaseController {
     assessorService.findAssessorAllocations(assessorId, status).map(allocations => Ok(Json.toJson(allocations)))
   }
 
-  def findAllocations(assessorIds: List[String], status: Option[AllocationStatus]): Action[AnyContent] = Action.async { implicit request =>
-    val res = assessorService.findAllocations(assessorIds, status)
-    res.map(r => Ok(Json.toJson(r)))
+  def findAllocations(): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    withJsonBody[AssessorAllocationRequest] { reqBody =>
+      val res = assessorService.findAllocations(reqBody.assessorIds, reqBody.status.map(AllocationStatuses.withName))
+      res.map(r => Ok(Json.toJson(r)))
+    }
   }
 
   def updateAllocationStatuses(assessorId: String): Action[JsValue] = Action.async(parse.json) { implicit request =>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -138,7 +138,7 @@ GET         /assessor/availability/find/:userId                          control
 GET         /assessor/availability/:locationName/:date                   controllers.AssessorController.findAvailableAssessorsForLocationAndDate(locationName: String, date: org.joda.time.LocalDate, skills: Seq[model.persisted.eventschedules.SkillType.SkillType])
 GET         /assessor/availability/count-submitted                       controllers.AssessorController.countSubmittedAvailability()
 GET         /assessor/:assessorId/allocations                            controllers.AssessorController.findAssessorAllocations(assessorId: String, status: Option[model.AllocationStatuses.AllocationStatus])
-GET         /assessor/allocations                                        controllers.AssessorController.findAllocations(assessorIds: List[String], status: Option[model.AllocationStatuses.AllocationStatus])
+POST        /assessor/allocations                                        controllers.AssessorController.findAllocations()
 PUT         /assessor/:assessorId/allocations                            controllers.AssessorController.updateAllocationStatuses(assessorId: String)
 
 # Events


### PR DESCRIPTION
When there are a lot of assessors, the GET endpoint blows up as the request's
url becomes too long. This sends the request payload in the body of a
POST request