### PR TITLE
FSET-1866 Sdip FS candidates who have been sifted out of FS schemes or withdrawn should be invited to FSB if Sdip is sifted in

### DIFF
--- a/app/model/ProgressStatuses.scala
+++ b/app/model/ProgressStatuses.scala
@@ -116,6 +116,7 @@ object ProgressStatuses {
   case object FAILED_AT_SIFT extends ProgressStatus(ApplicationStatus.FAILED_AT_SIFT)
   case object FAILED_AT_SIFT_NOTIFIED extends ProgressStatus(ApplicationStatus.FAILED_AT_SIFT)
   case object SDIP_FAILED_AT_SIFT extends ProgressStatus(ApplicationStatus.SIFT)
+  case object SIFT_FASTSTREAM_FAILED_SDIP_GREEN extends ProgressStatus(ApplicationStatus.SIFT)
 
   case object ASSESSMENT_CENTRE_AWAITING_ALLOCATION extends ProgressStatus(ApplicationStatus.ASSESSMENT_CENTRE)
   case object ASSESSMENT_CENTRE_ALLOCATION_UNCONFIRMED extends ProgressStatus(ApplicationStatus.ASSESSMENT_CENTRE)

--- a/app/model/command/ProgressResponse.scala
+++ b/app/model/command/ProgressResponse.scala
@@ -103,7 +103,8 @@ case class SiftProgressResponse(
   siftCompleted: Boolean = false,
   sdipFailedAtSift: Boolean = false,
   failedAtSift: Boolean = false,
-  failedAtSiftNotified: Boolean = false
+  failedAtSiftNotified: Boolean = false,
+  siftFaststreamFailedSdipGreen: Boolean = false
 )
 
 case class JobOfferProgressResponse(

--- a/app/model/report/ProgressStatusesReportLabels.scala
+++ b/app/model/report/ProgressStatusesReportLabels.scala
@@ -88,6 +88,7 @@ trait ProgressStatusesReportLabels {
     (progress.siftProgressResponse.failedAtSiftNotified, 405, SiftFailedNotified),
     (progress.siftProgressResponse.sdipFailedAtSift, 406, SdipSiftFailed),
     (progress.siftProgressResponse.siftCompleted, 407, SiftCompleted),
+    (progress.siftProgressResponse.siftFaststreamFailedSdipGreen, 410, SiftFaststreamFailedSdipGreen),
     (progress.assessmentCentre.awaitingAllocation, 420, AssessmentCentreAwaitingAllocation),
     (progress.assessmentCentre.allocationUnconfirmed, 423, AssessmentCentreAllocationUnconfirmed),
     (progress.assessmentCentre.allocationConfirmed, 426, AssessmentCentreAllocationConfirmed),
@@ -227,6 +228,7 @@ object ProgressStatusesReportLabels extends ProgressStatusesReportLabels {
   val SiftFailed = "failed_at_sift"
   val SiftFailedNotified = FAILED_AT_SIFT_NOTIFIED.toString.toLowerCase()
   val SdipSiftFailed = "sdip_failed_at_sift"
+  val SiftFaststreamFailedSdipGreen = SIFT_FASTSTREAM_FAILED_SDIP_GREEN.toString.toLowerCase()
   val ApplicationArchived = "application_archived"
   val FastPassAccepted = "fast_pass_accepted"
 

--- a/app/repositories/CommonBSONDocuments.scala
+++ b/app/repositories/CommonBSONDocuments.scala
@@ -165,7 +165,8 @@ trait CommonBSONDocuments extends BaseBSONReader {
             siftCompleted = getProgress(ProgressStatuses.SIFT_COMPLETED.key),
             failedAtSift = getProgress(ProgressStatuses.FAILED_AT_SIFT.key),
             failedAtSiftNotified = getProgress(ProgressStatuses.FAILED_AT_SIFT_NOTIFIED.key),
-            sdipFailedAtSift = getProgress(ProgressStatuses.SDIP_FAILED_AT_SIFT.key)
+            sdipFailedAtSift = getProgress(ProgressStatuses.SDIP_FAILED_AT_SIFT.key),
+            siftFaststreamFailedSdipGreen = getProgress(ProgressStatuses.SIFT_FASTSTREAM_FAILED_SDIP_GREEN.key)
           ),
           assessmentCentre = AssessmentCentre(
             awaitingAllocation = getProgress(ProgressStatuses.ASSESSMENT_CENTRE_AWAITING_ALLOCATION.key),

--- a/app/repositories/fsb/FsbRepository.scala
+++ b/app/repositories/fsb/FsbRepository.scala
@@ -109,6 +109,11 @@ class FsbMongoRepository(val dateTimeFactory: DateTimeFactory)(implicit mongo: (
         "applicationStatus" -> ApplicationStatus.ASSESSMENT_CENTRE,
         s"progress-status.${ProgressStatuses.ASSESSMENT_CENTRE_FAILED_SDIP_GREEN_NOTIFIED}" -> true
       ),
+      BSONDocument(
+        "applicationRoute" -> ApplicationRoute.SdipFaststream,
+        "applicationStatus" -> ApplicationStatus.SIFT,
+        s"progress-status.${ProgressStatuses.SIFT_FASTSTREAM_FAILED_SDIP_GREEN}" -> true
+      ),
       xdipQuery(ApplicationRoute.Sdip),
       xdipQuery(ApplicationRoute.Edip)
     ))


### PR DESCRIPTION
added new state SIFT_FASTSTREAM_FAILED_SDIP_GREEN to identify sdip faststream candidates whose fast stream schemes have either been sifted out or have been withdrawn but whose sdip has been sifted in. These candidates should be invited to attend FSB