### PR TITLE
FSET-1866 progress candidates straight to FSB who are in SIFT_COMPLETED and withdraw from all fs schemes, leaving just Sdip

### DIFF
--- a/app/services/application/ApplicationService.scala
+++ b/app/services/application/ApplicationService.scala
@@ -154,10 +154,11 @@ trait ApplicationService extends EventSink with CurrentSchemeStatusHelper {
 
       val shouldProgressToFSAC = onlyNonSiftableSchemesLeft || onlyNoSiftEvaluationRequiredSchemesWithFormFilled
 
-      // sdip faststream candidate who is awaiting allocation to an assessment centre and has withdrawn from
-      // all fast stream schemes and only has sdip left
+      // sdip faststream candidate who is awaiting allocation to an assessment centre or is in sift completed (not yet picked
+      // up by the assessment centre invite job) and has withdrawn from all fast stream schemes (or been sifted out) and only has sdip left
       val shouldProgressSdipFaststreamCandidateToFsb = greenSchemes == Set(Scheme.SdipId) && schemeStatus.size > 1 &&
-        latestProgressStatus.contains(ProgressStatuses.ASSESSMENT_CENTRE_AWAITING_ALLOCATION)
+        (latestProgressStatus.contains(ProgressStatuses.ASSESSMENT_CENTRE_AWAITING_ALLOCATION) ||
+        latestProgressStatus.contains(ProgressStatuses.SIFT_COMPLETED))
 
       if (shouldProgressSdipFaststreamCandidateToFsb) {
         appRepository.addProgressStatusAndUpdateAppStatus(applicationId, ProgressStatuses.FSB_AWAITING_ALLOCATION).map { _ =>


### PR DESCRIPTION
Also consider candidates who should be progressed to ASSESSMENT_CENTRE_AWAITING_ALLOCATION but have not yet been picked up by the job and so are still in SIFT_COMPLETED when withdrawing from schemes, just leaving Sdip. These candidates should be progressed straight to FSB