### PR TITLE
FSET-1871 progress candidates to SIFT_READY who are being put into SIFT_ENTERED by mistake

### DIFF
--- a/app/services/sift/ApplicationSiftService.scala
+++ b/app/services/sift/ApplicationSiftService.scala
@@ -75,7 +75,7 @@ trait ApplicationSiftService extends CurrentSchemeStatusHelper with CommonBSONDo
     val updates = FutureEx.traverseSerial(applications) { application =>
       FutureEx.futureToEither(application,
         applicationRepo.addProgressStatusAndUpdateAppStatus(application.applicationId,
-          progressStatusForSiftStage(application.currentSchemeStatus.map(_.schemeId)))
+          progressStatusForSiftStage(application.currentSchemeStatus.collect { case s if s.result == Green.toString => s.schemeId } ))
       )
     }
 

--- a/test/services/sift/ApplicationSiftServiceSpec.scala
+++ b/test/services/sift/ApplicationSiftServiceSpec.scala
@@ -128,6 +128,26 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitWithAppSpec {
       }
     }
 
+    "progress candidate to SIFT_READY (eligible to be sifted) when the candidate is only in the running for schemes " +
+      "requiring a numeric test" in new TestFixture {
+      val applicationToProgressToSift = List(
+        ApplicationForSift("appId1", "userId1", ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED,
+          List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString),
+            SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Red.toString)
+          )
+        )
+      )
+
+      (mockAppRepo.addProgressStatusAndUpdateAppStatus _).expects("appId1", ProgressStatuses.SIFT_READY).returningAsync
+
+      whenReady(service.progressApplicationToSiftStage(applicationToProgressToSift)) { results =>
+
+        val failedApplications = Nil
+        val passedApplications = Seq(applicationToProgressToSift.head)
+        results mustBe SerialUpdateResult(failedApplications, passedApplications)
+      }
+    }
+
     "find relevant applications for scheme sifting" in new TestFixture {
       val candidates = Seq(Candidate("userId1", Some("appId1"), Some(""), Some(""), Some(""), Some(""), Some(LocalDate.now), Some(Address("")),
         Some("E1 7UA"), Some("UK"), Some(ApplicationRoute.Faststream), Some("")))

--- a/test/services/sift/ApplicationSiftServiceSpec.scala
+++ b/test/services/sift/ApplicationSiftServiceSpec.scala
@@ -129,11 +129,32 @@ class ApplicationSiftServiceSpec extends ScalaMockUnitWithAppSpec {
     }
 
     "progress candidate to SIFT_READY (eligible to be sifted) when the candidate is only in the running for schemes " +
-      "requiring a numeric test" in new TestFixture {
+      "requiring a numeric test and form based schemes are failed" in new TestFixture {
       val applicationToProgressToSift = List(
         ApplicationForSift("appId1", "userId1", ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED,
           List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString),
             SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Red.toString)
+          )
+        )
+      )
+
+      (mockAppRepo.addProgressStatusAndUpdateAppStatus _).expects("appId1", ProgressStatuses.SIFT_READY).returningAsync
+
+      whenReady(service.progressApplicationToSiftStage(applicationToProgressToSift)) { results =>
+
+        val failedApplications = Nil
+        val passedApplications = Seq(applicationToProgressToSift.head)
+        results mustBe SerialUpdateResult(failedApplications, passedApplications)
+      }
+    }
+
+    "progress candidate to SIFT_READY (eligible to be sifted) when the candidate is still in the running for schemes " +
+      "requiring a numeric test and Generalist and form based schemes are failed" in new TestFixture {
+      val applicationToProgressToSift = List(
+        ApplicationForSift("appId1", "userId1", ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED,
+          List(SchemeEvaluationResult(SchemeId("Commercial"), EvaluationResults.Green.toString),
+            SchemeEvaluationResult(SchemeId("GovernmentSocialResearchService"), EvaluationResults.Red.toString),
+            SchemeEvaluationResult(SchemeId("Generalist"), EvaluationResults.Green.toString)
           )
         )
       )


### PR DESCRIPTION
fix to move candidates who are still in the running for numeric schemes (which require a sift) and are no longer in the running for schemes requiring a form to be filled in after video interview into SIFT_READY status so they can be sifted