### PR TITLE
FSET-1878: Add a new scheduler for sdipfaststream phase 3 passes, and limit the old one to faststream only

### DIFF
--- a/app/model/NotificationTestType.scala
+++ b/app/model/NotificationTestType.scala
@@ -73,7 +73,15 @@ object Phase1SuccessTestType
 
 object Phase3SuccessTestType
   extends SuccessTestType(ApplicationStatus.PHASE3_TESTS_PASSED, PHASE3_TESTS_PASSED_NOTIFIED,
-    ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED, "fset_faststream_app_online_phase3_test_success")
+    ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED, "fset_faststream_app_online_phase3_test_success") {
+  override val applicationRoutes = List(ApplicationRoute.Faststream)
+}
+
+object Phase3SuccessSdipFsTestType
+  extends SuccessTestType(ApplicationStatus.PHASE3_TESTS_PASSED, PHASE3_TESTS_PASSED_NOTIFIED,
+    ApplicationStatus.PHASE3_TESTS_PASSED_NOTIFIED, "fset_faststream_app_online_phase3_test_success_sdipfs") {
+  override val applicationRoutes = List(ApplicationRoute.SdipFaststream)
+}
 
 object FailedSdipFsTestType
   extends FailedTestTypeSdipFs("fset_faststream_app_online_sdip_fs_test_failed", ApplicationRoute.SdipFaststream)

--- a/app/scheduler/Scheduler.scala
+++ b/app/scheduler/Scheduler.scala
@@ -51,6 +51,7 @@ trait Scheduler extends RunningOfScheduledJobs {
     maybeInitScheduler(FailedSdipFsTestJobConfig, FailedSdipFsTestJob),
     maybeInitScheduler(SuccessPhase1TestJobConfig, SuccessPhase1TestJob),
     maybeInitScheduler(SuccessPhase3TestJobConfig, SuccessPhase3TestJob),
+    maybeInitScheduler(SuccessPhase3SdipFsTestJobConfig, SuccessPhase3SdipFsTestJob),
     maybeInitScheduler(RetrievePhase1ResultsJobConfig, RetrievePhase1ResultsJob),
     maybeInitScheduler(RetrievePhase2ResultsJobConfig, RetrievePhase2ResultsJob),
     maybeInitScheduler(EvaluatePhase1ResultJobConfig, EvaluatePhase1ResultJob),

--- a/app/scheduler/onlinetesting/SuccessTestJob.scala
+++ b/app/scheduler/onlinetesting/SuccessTestJob.scala
@@ -39,6 +39,12 @@ object SuccessPhase3TestJob extends SuccessTestJob {
   val config = SuccessPhase3TestJobConfig
 }
 
+object SuccessPhase3SdipFsTestJob extends SuccessTestJob {
+  override val service = Phase3TestService
+  override val successType: SuccessTestType = Phase3SuccessSdipFsTestType
+  val config = SuccessPhase3TestJobConfig
+}
+
 trait SuccessTestJob extends SingleInstanceScheduledJob[BasicJobConfig[ScheduledJobConfig]] {
   val service: OnlineTestService
   val successType: SuccessTestType
@@ -58,4 +64,9 @@ object SuccessPhase1TestJobConfig extends BasicJobConfig[ScheduledJobConfig](
 object SuccessPhase3TestJobConfig extends BasicJobConfig[ScheduledJobConfig](
   configPrefix = "scheduling.online-testing.success-phase3-test-job",
   name = "SuccessPhase3TestJob"
+)
+
+object SuccessPhase3SdipFsTestJobConfig extends BasicJobConfig[ScheduledJobConfig](
+  configPrefix = "scheduling.online-testing.success-phase3-sdipfs-test-job",
+  name = "SuccessPhase3SdipFsTestJob"
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -288,6 +288,12 @@ scheduling {
       initialDelaySecs = 34
       intervalSecs = 30
     }
+    success-phase3-sdipfs-test-job {
+      enabled = false
+      lockId = "success-phase3-sdipfs-test-job-lock-coordinator"
+      initialDelaySecs = 35
+      intervalSecs = 30
+    }
     retrieve-phase1-results-job {
       enabled = false
       lockId = "retrieve-phase1-results-job-lock-coordinator"

--- a/it/repositories/application/GeneralApplicationMongoRepositorySpec.scala
+++ b/it/repositories/application/GeneralApplicationMongoRepositorySpec.scala
@@ -414,7 +414,7 @@ class GeneralApplicationMongoRepositorySpec extends MongoRepositorySpec with UUI
 
     "find a candidate that needs to be notified of successful phase3 test results" in new NewApplication {
       val appStatus = ApplicationStatus.PHASE3_TESTS_PASSED
-      val appRoute = None
+      val appRoute = Some(ApplicationRoute.Faststream)
       createApplication()
 
       val applicationResponse = repository.findTestForNotification(Phase3SuccessTestType).futureValue


### PR DESCRIPTION
Needs: https://github.com/hmrc/fset-email-renderer/pull/40