### PR TITLE
FSET-2043: Handle numerical test completion callbacks

### DIFF
--- a/app/model/persisted/sift/SiftTestGroupWithAppId.scala
+++ b/app/model/persisted/sift/SiftTestGroupWithAppId.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model.persisted.sift
+
+import model.persisted.CubiksTest
+import org.joda.time.DateTime
+import play.api.libs.json.Json
+import reactivemongo.bson.{ BSONDocument, BSONHandler, Macros }
+import repositories.BSONDateTimeHandler
+
+case class SiftTestGroupWithAppId(applicationId: String, expirationDate: DateTime, tests: Option[List[CubiksTest]])
+
+object SiftTestGroupWithAppId {
+  implicit val bsonHandler: BSONHandler[BSONDocument, SiftTestGroupWithAppId] = Macros.handler[SiftTestGroupWithAppId]
+  implicit val siftTestGroupFormat = Json.format[SiftTestGroupWithAppId]
+}

--- a/test/controllers/CubiksTestControllerSpec.scala
+++ b/test/controllers/CubiksTestControllerSpec.scala
@@ -20,10 +20,10 @@ import model.Exceptions.CannotFindTestByCubiksId
 import model.exchange.CubiksTestResultReady
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{ eq => eqTo, _ }
-import org.mockito.ArgumentMatchers.{ eq => eqTo, _ }
 import org.mockito.Mockito._
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
+import services.NumericalTestsService
 import services.stc.StcEventService
 import services.onlinetesting.phase1.Phase1TestService
 import services.onlinetesting.phase2.Phase2TestService
@@ -36,12 +36,14 @@ class CubiksTestControllerSpec extends UnitWithAppSpec {
 
   val mockPhase1TestService = mock[Phase1TestService]
   val mockPhase2TestService = mock[Phase2TestService]
+  val mockNumericalTestService = mock[NumericalTestsService]
   val mockEventService = mock[StcEventService]
 
   def controllerUnderTest = new CubiksTestsController {
     val phase1TestService = mockPhase1TestService
     val eventService = mockEventService
     val phase2TestService = mockPhase2TestService
+    val numericalTestService: NumericalTestsService = mockNumericalTestService
   }
 
   "start" should {
@@ -104,6 +106,8 @@ class CubiksTestControllerSpec extends UnitWithAppSpec {
       ).thenReturn(Future.failed(CannotFindTestByCubiksId("")))
       when(mockPhase2TestService.markAsCompleted(eqTo(cubiksUserId))(any[HeaderCarrier], any[RequestHeader])
       ).thenReturn(Future.failed(CannotFindTestByCubiksId("")))
+      when(mockNumericalTestService.markAsCompleted(eqTo(cubiksUserId))(any[HeaderCarrier], any[RequestHeader])
+      ).thenReturn(Future.failed(CannotFindTestByCubiksId("")))
 
       val response = controllerUnderTest.complete(cubiksUserId)(fakeRequest(""))
       status(response) mustBe NOT_FOUND
@@ -136,6 +140,8 @@ class CubiksTestControllerSpec extends UnitWithAppSpec {
       when(mockPhase1TestService.markAsCompleted(eqTo(token))(any[HeaderCarrier], any[RequestHeader])
       ).thenReturn(Future.failed(CannotFindTestByCubiksId("")))
       when(mockPhase2TestService.markAsCompleted(eqTo(token))(any[HeaderCarrier], any[RequestHeader])
+      ).thenReturn(Future.failed(CannotFindTestByCubiksId("")))
+      when(mockNumericalTestService.markAsCompleted(eqTo(token))(any[HeaderCarrier], any[RequestHeader])
       ).thenReturn(Future.failed(CannotFindTestByCubiksId("")))
 
       val response = controllerUnderTest.completeTestByToken(token)(fakeRequest)


### PR DESCRIPTION
* Handle main callback from cubiks via gateway
* Handle callback from candidate frontend(complete by token)