### PR TITLE
FSET-2139 Add ability to specify which eTray is selected instead of it being random

### DIFF
--- a/app/services/onlinetesting/phase2/Phase2TestSelector.scala
+++ b/app/services/onlinetesting/phase2/Phase2TestSelector.scala
@@ -17,6 +17,7 @@
 package services.onlinetesting.phase2
 
 import config.{ Phase2Schedule, Phase2TestsConfig }
+import play.api.Logger
 
 import scala.util.Random
 
@@ -29,12 +30,16 @@ trait Phase2TestSelector {
     val unallocatedExists = getUnallocatedSchedules(currentScheduleIds) != List.empty
     val numberOfSelectors = testConfig.schedules.size
 
-    if (unallocatedExists) {
+    val result = if (unallocatedExists) {
       getRandomScheduleWithName(currentScheduleIds)
     } else {
       val schedule = testConfig.schedules.values.find(_.scheduleId == currentScheduleIds(currentScheduleIds.size % numberOfSelectors)).head
-      (testConfig.scheduleNameByScheduleId(schedule.scheduleId), schedule)
+      getAlwaysChooseSchedule.getOrElse((testConfig.scheduleNameByScheduleId(schedule.scheduleId), schedule))
     }
+    testConfig.alwaysChooseSchedule.foreach { scheduleName =>
+      Logger.info(s"AlwaysChooseSchedule is configured so all candidates will be invited to take Etray schedule: $scheduleName")
+    }
+    result
   }
 
   private def getRandomScheduleWithName(currentScheduleIds: List[Int]): (String, Phase2Schedule) = {
@@ -42,10 +47,12 @@ trait Phase2TestSelector {
 
     require(schedules.nonEmpty, "Phase2 schedule list cannot be empty")
     val schedule = schedules.toSeq(Random.nextInt(schedules.size))
-    (testConfig.scheduleNameByScheduleId(schedule.scheduleId), schedule)
+    getAlwaysChooseSchedule.getOrElse((testConfig.scheduleNameByScheduleId(schedule.scheduleId), schedule))
   }
 
-  private def getUnallocatedSchedules(currentScheduleIds: List[Int]) = {
+  private def getUnallocatedSchedules(currentScheduleIds: List[Int])=
     testConfig.schedules.values.filter(schedule => !currentScheduleIds.contains(schedule.scheduleId))
-  }
+
+  private def getAlwaysChooseSchedule=
+    testConfig.alwaysChooseSchedule.map ( scheduleName => (scheduleName, testConfig.schedules(scheduleName)) )
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -134,7 +134,9 @@ microservice {
             scheduleId = 16738
             assessmentId = 157
           }
-        }
+        }//,
+        # specify this key to always choose a specific schedule - only used during testing when setting up a new campaign
+        //alwaysChooseSchedule = "oria"
       }
       numericalTests {
         schedules = {

--- a/test/config/Phase2TestsConfigSpec.scala
+++ b/test/config/Phase2TestsConfigSpec.scala
@@ -22,7 +22,7 @@ import testkit.UnitSpec
 class Phase2TestsConfigSpec extends UnitSpec {
 
   "Schedule name by schedule id" should {
-    val config = Phase2TestsConfig(10, 20, Map("daro" -> DaroSchedule))
+    val config = Phase2TestsConfig(10, 20, Map("daro" -> DaroSchedule), None)
 
     "return schedule name by schedule id" in {
       val name = config.scheduleNameByScheduleId(DaroSchedule.scheduleId)
@@ -38,13 +38,21 @@ class Phase2TestsConfigSpec extends UnitSpec {
 
   "schedule for invigilated e-tray" should {
     "return daro" in {
-      val config = Phase2TestsConfig(10, 20, Map("oria" -> OriaSchedule, "daro" -> DaroSchedule))
+      val config = Phase2TestsConfig(10, 20, Map("oria" -> OriaSchedule, "daro" -> DaroSchedule), None)
       config.scheduleForInvigilatedETray mustBe DaroSchedule
     }
 
     "throw an exception when there is no daro schedule" in {
       an[IllegalArgumentException] must be thrownBy {
-        Phase2TestsConfig(10, 20, Map("oria" -> OriaSchedule))
+        Phase2TestsConfig(10, 20, Map("oria" -> OriaSchedule), None)
+      }
+    }
+  }
+
+  "when configuring phase2 tests to always invite a candidate to a specific eTray" should {
+    "throw an exception when the specified eTray is not in the schedule list" in {
+      an[IllegalArgumentException] must be thrownBy {
+        Phase2TestsConfig(10, 20, Map("oria" -> OriaSchedule), Some("BOOM"))
       }
     }
   }

--- a/test/services/onlinetesting/phase1/Phase1TestServiceSpec.scala
+++ b/test/services/onlinetesting/phase1/Phase1TestServiceSpec.scala
@@ -59,7 +59,7 @@ class Phase1TestServiceSpec extends UnitSpec with ExtendedTimeout
       List("sjq")
     ),
     phase2Tests = Phase2TestsConfig(expiryTimeInDays = 5, expiryTimeInDaysForInvigilatedETray = 90,
-      Map("daro" -> Phase2ScheduleExamples.DaroSchedule)),
+      Map("daro" -> Phase2ScheduleExamples.DaroSchedule), None),
     numericalTests = NumericalTestsConfig(Map(NumericalTestsConfig.numericalTestScheduleName -> NumericalTestSchedule(12345, 123))),
     reportConfig = ReportConfig(1, 2, "en-GB"),
     candidateAppUrl = "http://localhost:9284",

--- a/test/services/onlinetesting/phase2/Phase2TestSelectorSpec.scala
+++ b/test/services/onlinetesting/phase2/Phase2TestSelectorSpec.scala
@@ -39,6 +39,15 @@ class Phase2TestSelectorSpec extends UnitSpec {
       randomSchedules.distinct must contain theSameElementsAs schedules
     }
 
+    "always choose the same schedule if configured to do so" in {
+      val alwaysChooseSchedule = "ward"
+      val schedules = Map("daro" -> DaroSchedule, "oria" -> OriaSchedule, "ward" -> WardSchedule)
+      val selector = createSelector(schedules, Some(alwaysChooseSchedule))
+      val randomSchedules = 1 to 1000 map (_ => selector.getNextSchedule())
+
+      randomSchedules.distinct must contain theSameElementsAs Seq(alwaysChooseSchedule -> WardSchedule)
+    }
+
     "return a schedule randomly for the first n schedules defined and then repeat those schedules in subsequent calls" in {
       val schedules = Map("daro" -> DaroSchedule, "oria" -> OriaSchedule, "ward" -> WardSchedule)
       val selector = createSelector(schedules)
@@ -58,8 +67,8 @@ class Phase2TestSelectorSpec extends UnitSpec {
     }
   }
 
-
-  private def createSelector(schedules: Map[String, Phase2Schedule]): Phase2TestSelector = new Phase2TestSelector {
-    def testConfig = Phase2TestsConfig(1, 90, schedules)
+  private def createSelector(schedules: Map[String, Phase2Schedule],
+                             alwaysChooseSchedule: Option[String] = None): Phase2TestSelector = new Phase2TestSelector {
+    def testConfig = Phase2TestsConfig(1, 90, schedules, alwaysChooseSchedule)
   }
 }

--- a/test/services/onlinetesting/phase2/Phase2TestServiceSpec.scala
+++ b/test/services/onlinetesting/phase2/Phase2TestServiceSpec.scala
@@ -627,7 +627,6 @@ class Phase2TestServiceSpec extends UnitSpec with ExtendedTimeout {
       an[CannotResetPhase2Tests] must be thrownBy
         Await.result(phase2TestService.resetTests(onlineTestApplication, "createdBy"), 1 seconds)
     }
-
   }
 
   "Extend time for expired test" should {
@@ -890,7 +889,7 @@ class Phase2TestServiceSpec extends UnitSpec with ExtendedTimeout {
         List("sjq", "bq"),
         List("sjq")
       ),
-      phase2Tests = Phase2TestsConfig(expiryTimeInDays = 5, expiryTimeInDaysForInvigilatedETray = 90, availableSchedules),
+      phase2Tests = Phase2TestsConfig(expiryTimeInDays = 5, expiryTimeInDaysForInvigilatedETray = 90, availableSchedules, None),
       numericalTests = NumericalTestsConfig(Map(NumericalTestsConfig.numericalTestScheduleName -> NumericalTestSchedule(12345, 123))),
       reportConfig = ReportConfig(1, 2, "en-GB"),
       candidateAppUrl = "http://localhost:9284",


### PR DESCRIPTION
Add ability to specify which eTray is selected instead of it being random. Used to test during campaign setup