### PR TITLE
FSET-2402: Ensure single email is sent for all P2 invitations

### DIFF
--- a/app/connectors/OnlineTestsGatewayClient.scala
+++ b/app/connectors/OnlineTestsGatewayClient.scala
@@ -84,7 +84,7 @@ trait OnlineTestsGatewayClient {
 
     http.GET(url = s"$url/$root/faststream/psi-cancel-assessment/${request.orderId}").map { response =>
       if (response.status == OK) {
-        Logger.debug(s"psiRegisterApplicant response - ${response.json.toString}")
+        Logger.debug(s"psiCancelAssessment response - ${response.json.toString}")
         response.json.as[AssessmentCancelAcknowledgementResponse]
       } else {
         throw new ConnectorException(s"There was a general problem connecting to Online Tests Gateway. HTTP response was $response")

--- a/test/services/onlinetesting/phase2/Phase2TestService2Spec.scala
+++ b/test/services/onlinetesting/phase2/Phase2TestService2Spec.scala
@@ -117,8 +117,10 @@ class Phase2TestService2Spec extends UnitSpec with ExtendedTimeout {
       verify(auditServiceMock, never()).logEventNoRequest("OnlineTestInvitationEmailSent", auditDetailsWithEmail)
     }
 
-    "save tests for a candidate after registration and send emails" in new Phase2TestServiceFixture {
-      when(otRepositoryMock2.getTestGroup(any[String])).thenReturnAsync(Some(phase2TestProfileWithNoTest))
+    "save tests for a candidate after registration and send ONE email" in new Phase2TestServiceFixture {
+      when(otRepositoryMock2.getTestGroup(any[String]))
+        .thenReturnAsync(Some(phase2TestProfileWithNoTest))
+        .thenReturnAsync(Some(phase2TestProfile))
       when(otRepositoryMock2.insertOrUpdateTestGroup(any[String], any[Phase2TestGroup2])).thenReturnAsync()
       when(onlineTestsGatewayClientMock.psiRegisterApplicant(any[RegisterCandidateRequest]))
         .thenReturnAsync(aoa)
@@ -127,8 +129,8 @@ class Phase2TestService2Spec extends UnitSpec with ExtendedTimeout {
 
       verify(otRepositoryMock2, times(2)).insertOrUpdateTestGroup(any[String], any[Phase2TestGroup2])
       verify(onlineTestsGatewayClientMock, times(2)).psiRegisterApplicant(any[RegisterCandidateRequest])
-      verify(emailClientMock, atLeastOnce()).sendOnlineTestInvitation(anyString(), anyString(), any[DateTime])(any[HeaderCarrier])
-      verify(auditServiceMock, atLeastOnce()).logEventNoRequest("OnlineTestInvitationEmailSent", auditDetailsWithEmail)
+      verify(emailClientMock, times(1)).sendOnlineTestInvitation(anyString(), anyString(), any[DateTime])(any[HeaderCarrier])
+      verify(auditServiceMock, times(1)).logEventNoRequest("OnlineTestInvitationEmailSent", auditDetailsWithEmail)
     }
   }
 


### PR DESCRIPTION
Candidates were receiving 2 emails in phase 2(one per test). This ensures they receives just one email for both invitations.