### PR TITLE
FSET-2535: DAT civilServantEligible is set false

### DIFF
--- a/conf/schemes.yaml
+++ b/conf/schemes.yaml
@@ -10,7 +10,7 @@
 - id: DigitalAndTechnology
   code: DAT
   name: Digital, Data & Technology
-  civilServantEligible: true
+  civilServantEligible: false
   degree:
     required: Degree_22
     specificRequirement: false


### PR DESCRIPTION
To test if the schemes appear correctly for civil service eligibility.Setting the DAT to false from default True.